### PR TITLE
Enable chart specific options to be serialized

### DIFF
--- a/Source/Extensions/Blazorise.Charts/Base/BaseChart.cs
+++ b/Source/Extensions/Blazorise.Charts/Base/BaseChart.cs
@@ -98,7 +98,7 @@ namespace Blazorise.Charts.Base
             {
                 dirty = false;
 
-                await JS.SetChartData( JSRuntime, ElementId, Type, DataJsonString ?? (object)Data, OptionsJsonString ?? (object)Options );
+                await JS.SetChartData( JSRuntime, ElementId, Type, Data, Options );
             }
         }
 
@@ -120,18 +120,6 @@ namespace Blazorise.Charts.Base
         /// Defines the chart options.
         /// </summary>
         [Parameter] protected TOptions Options { get; set; }
-
-        /// <summary>
-        /// Defines the chart data that is serialized as json string.
-        /// </summary>
-        [Obsolete( "This parameter will likely be removed in the future as it's just a temporary feature until Blazor implements better serializer." )]
-        [Parameter] protected string DataJsonString { get; set; }
-
-        /// <summary>
-        /// Defines the chart options that is serialized as json string.
-        /// </summary>
-        [Obsolete( "This parameter will likely be removed in the future as it's just a temporary feature until Blazor implements better serializer." )]
-        [Parameter] protected string OptionsJsonString { get; set; }
 
         [Inject] IJSRuntime JSRuntime { get; set; }
 

--- a/Source/Extensions/Blazorise.Charts/Base/BaseChart.cs
+++ b/Source/Extensions/Blazorise.Charts/Base/BaseChart.cs
@@ -98,7 +98,7 @@ namespace Blazorise.Charts.Base
             {
                 dirty = false;
 
-                await JS.SetChartData( JSRuntime, ElementId, Type, Data, Options );
+                await JS.SetChartData( JSRuntime, ElementId, Type, Data, Options, DataJsonString, OptionsJsonString );
             }
         }
 
@@ -120,6 +120,18 @@ namespace Blazorise.Charts.Base
         /// Defines the chart options.
         /// </summary>
         [Parameter] protected TOptions Options { get; set; }
+
+        /// <summary>
+        /// Defines the chart data that is serialized as json string.
+        /// </summary>
+        [Obsolete("This parameter will likely be removed in the future as it's just a temporary feature until Blazor implements better serializer.")]
+        [Parameter] protected string DataJsonString { get; set; }
+
+        /// <summary>
+        /// Defines the chart options that is serialized as json string.
+        /// </summary>
+        [Obsolete("This parameter will likely be removed in the future as it's just a temporary feature until Blazor implements better serializer.")]
+        [Parameter] protected string OptionsJsonString { get; set; }
 
         [Inject] IJSRuntime JSRuntime { get; set; }
 

--- a/Source/Extensions/Blazorise.Charts/Base/BaseChart.cs
+++ b/Source/Extensions/Blazorise.Charts/Base/BaseChart.cs
@@ -124,13 +124,13 @@ namespace Blazorise.Charts.Base
         /// <summary>
         /// Defines the chart data that is serialized as json string.
         /// </summary>
-        [Obsolete("This parameter will likely be removed in the future as it's just a temporary feature until Blazor implements better serializer.")]
+        [Obsolete( "This parameter will likely be removed in the future as it's just a temporary feature until Blazor implements better serializer." )]
         [Parameter] protected string DataJsonString { get; set; }
 
         /// <summary>
         /// Defines the chart options that is serialized as json string.
         /// </summary>
-        [Obsolete("This parameter will likely be removed in the future as it's just a temporary feature until Blazor implements better serializer.")]
+        [Obsolete( "This parameter will likely be removed in the future as it's just a temporary feature until Blazor implements better serializer." )]
         [Parameter] protected string OptionsJsonString { get; set; }
 
         [Inject] IJSRuntime JSRuntime { get; set; }

--- a/Source/Extensions/Blazorise.Charts/ChartData.cs
+++ b/Source/Extensions/Blazorise.Charts/ChartData.cs
@@ -1,9 +1,6 @@
 ﻿#region Using directives
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.Serialization;
-using System.Threading.Tasks;
 #endregion
 
 namespace Blazorise.Charts
@@ -39,6 +36,22 @@ namespace Blazorise.Charts
     [DataContract]
     public class ChartDataset<T>
     {
+
+        public ChartDataset() { }
+
+        protected ChartDataset(
+            string label,
+            List<string> backgroundColor,
+            List<string> borderColor,
+            int borderWidth
+        )
+        {
+            Label = label;
+            BackgroundColor = backgroundColor;
+            BorderColor = borderColor;
+            BorderWidth = borderWidth;
+        }
+
         /// <summary>
         /// Defines the dataset display name.
         /// </summary>
@@ -70,20 +83,31 @@ namespace Blazorise.Charts
         public int BorderWidth { get; set; } = 1;
     }
 
+    /// <remarks>
+    /// Defaults values as per https://www.chartjs.org/docs/latest/charts/line.html#dataset-properties
+    /// </remarks>
     [DataContract]
     public class LineChartDataset<T> : ChartDataset<T>
     {
+        public LineChartDataset() : base(
+            label: string.Empty,
+            backgroundColor: new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) },
+            borderColor: new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) },
+            borderWidth: 3
+        )
+        { }
+
         /// <summary>
         /// Length and spacing of dashes.
         /// </summary>
         [DataMember( EmitDefaultValue = false )]
-        public List<int> BorderDash { get; set; }
+        public List<int> BorderDash { get; set; } = new List<int>();
 
         /// <summary>
         /// Offset for line dashes.
         /// </summary>
         [DataMember]
-        public int BorderDashOffset { get; set; }
+        public float BorderDashOffset { get; set; }
 
         /// <summary>
         /// Fill the area under the line.
@@ -92,34 +116,34 @@ namespace Blazorise.Charts
         public bool Fill { get; set; } = true;
 
         /// <summary>
-        /// Bezier curve tension of the line. Set to 0 to draw straightlines. This option is ignored if monotone cubic interpolation is used.
+        /// Bezier curve tension of the line. Set to 0f to draw straightlines. This option is ignored if monotone cubic interpolation is used.
         /// </summary>
         [DataMember]
-        public int LineTension { get; set; }
+        public float LineTension { get; set; } = 0.4f;
 
         /// <summary>
         /// The fill color for points.
         /// </summary>
         [DataMember( EmitDefaultValue = false )]
-        public List<string> PointBackgroundColor { get; set; }
+        public List<string> PointBackgroundColor { get; set; } = new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) };
 
         /// <summary>
         /// The border color for points.
         /// </summary>
         [DataMember( EmitDefaultValue = false )]
-        public List<string> PointBorderColor { get; set; }
+        public List<string> PointBorderColor { get; set; } = new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) };
 
         /// <summary>
         /// The width of the point border in pixels.
         /// </summary>
         [DataMember]
-        public int PointBorderWidth { get; set; }
+        public int PointBorderWidth { get; set; } = 1;
 
         /// <summary>
         /// The radius of the point shape. If set to 0, the point is not rendered.
         /// </summary>
         [DataMember]
-        public float PointRadius { get; set; }
+        public float PointRadius { get; set; } = 3.0f;
 
         /// <summary>
         /// If false, the line is not drawn for this dataset.
@@ -140,46 +164,73 @@ namespace Blazorise.Charts
         public bool SteppedLine { get; set; }
     }
 
+    /// <remarks>
+    /// Defaults as per https://www.chartjs.org/docs/latest/charts/bar.html#dataset-properties
+    /// </remarks>
     [DataContract]
     public class BarChartDataset<T> : ChartDataset<T>
     {
+        public BarChartDataset() : base(
+            label: string.Empty,
+            backgroundColor: new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) },
+            borderColor: new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) },
+            borderWidth: 0
+        )
+        { }
+
         /// <summary>
         /// The fill colour of the bars when hovered.
         /// </summary>
+        /// <remarks>Default as per https://www.chartjs.org/docs/latest/configuration/elements.html#rectangle-configuration </remarks>
         [DataMember( EmitDefaultValue = false )]
-        public List<string> HoverBackgroundColor { get; set; }
+        public List<string> HoverBackgroundColor { get; set; } = new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) };
 
         /// <summary>
         /// The stroke colour of the bars when hovered.
         /// </summary>
+        /// <remarks>Default as per https://www.chartjs.org/docs/latest/configuration/elements.html#rectangle-configuration </remarks>
         [DataMember( EmitDefaultValue = false )]
-        public List<string> HoverBorderColor { get; set; }
+        public List<string> HoverBorderColor { get; set; } = new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) };
 
         /// <summary>
         /// The stroke width of the bars when hovered.
         /// </summary>
         [DataMember]
-        public int HoverBorderWidth { get; set; }
+        public int HoverBorderWidth { get; set; } = 1;
     }
 
+    /// <remarks>
+    /// Defaults as per https://www.chartjs.org/docs/latest/charts/doughnut.html#dataset-properties
+    /// </remarks>
     [DataContract]
     public class PieChartDataset<T> : ChartDataset<T>
     {
+        public PieChartDataset() : base(
+            label: string.Empty,
+            backgroundColor: new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) },
+            borderColor: new List<string> { ChartColor.FromRgba(0xF, 0xF, 0xF, 1.0f) },
+            borderWidth: 2
+        )
+        { }
+
         /// <summary>
         /// The fill colour of the arcs when hovered.
         /// </summary>
+        /// <remarks>Default as per https://www.chartjs.org/docs/latest/configuration/elements.html#arc-configuration </remarks>
         [DataMember( EmitDefaultValue = false )]
-        public List<string> HoverBackgroundColor { get; set; }
+        public List<string> HoverBackgroundColor { get; set; } = new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) };
 
         /// <summary>
         /// The stroke colour of the arcs when hovered.
         /// </summary>
+        /// <remarks>Default as per https://www.chartjs.org/docs/latest/configuration/elements.html#arc-configuration </remarks>
         [DataMember( EmitDefaultValue = false )]
-        public List<string> HoverBorderColor { get; set; }
+        public List<string> HoverBorderColor { get; set; } = new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) };
 
         /// <summary>
         /// The stroke width of the arcs when hovered.
         /// </summary>
+        /// <remarks>Default as per https://www.chartjs.org/docs/latest/configuration/elements.html#arc-configuration </remarks>
         [DataMember]
         public int HoverBorderWidth { get; set; }
     }
@@ -190,42 +241,67 @@ namespace Blazorise.Charts
         // same as pie chart
     }
 
+    /// <remarks>
+    /// Defaults as per https://www.chartjs.org/docs/latest/charts/polar.html#dataset-properties
+    /// </remarks>
     [DataContract]
     public class PolarAreaChartDataset<T> : ChartDataset<T>
     {
+        public PolarAreaChartDataset() : base(
+            label: string.Empty,
+            backgroundColor: new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) },
+            borderColor: new List<string> { ChartColor.FromRgba(0xF, 0xF, 0xF, 1.0f) },
+            borderWidth: 2
+        )
+        { }
+
         /// <summary>
         /// The fill colour of the arcs when hovered.
         /// </summary>
+        /// <remarks>Default as per https://www.chartjs.org/docs/latest/configuration/elements.html#arc-configuration </remarks>
         [DataMember( EmitDefaultValue = false )]
-        public List<string> HoverBackgroundColor { get; set; }
+        public List<string> HoverBackgroundColor { get; set; } = new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) };
 
         /// <summary>
         /// The stroke colour of the arcs when hovered.
         /// </summary>
+        /// <remarks>Default as per https://www.chartjs.org/docs/latest/configuration/elements.html#arc-configuration </remarks>
         [DataMember( EmitDefaultValue = false )]
-        public List<string> HoverBorderColor { get; set; }
+        public List<string> HoverBorderColor { get; set; } = new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) };
 
         /// <summary>
         /// The stroke width of the arcs when hovered.
         /// </summary>
+        /// <remarks>Default as per https://www.chartjs.org/docs/latest/configuration/elements.html#arc-configuration </remarks>
         [DataMember]
         public int HoverBorderWidth { get; set; }
     }
 
+    /// <remarks>
+    /// Defaults from https://www.chartjs.org/docs/latest/charts/radar.html#dataset-properties
+    /// </remarks>
     [DataContract]
     public class RadarChartDataset<T> : ChartDataset<T>
     {
+        public RadarChartDataset() : base(
+            label: string.Empty,
+            backgroundColor: new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) },
+            borderColor: new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) },
+            borderWidth: 3
+        )
+        { }
+
         /// <summary>
         /// How to fill the area under the line.
         /// </summary>
         [DataMember]
-        public bool Fill { get; set; }
+        public bool Fill { get; set; } = true;
 
         /// <summary>
         /// Bezier curve tension of the line. Set to 0 to draw straightlines.
         /// </summary>
         [DataMember]
-        public float LineTension { get; set; }
+        public float LineTension { get; set; } = 0.4f;
     }
 
     [DataContract]

--- a/Source/Extensions/Blazorise.Charts/ChartData.cs
+++ b/Source/Extensions/Blazorise.Charts/ChartData.cs
@@ -91,8 +91,8 @@ namespace Blazorise.Charts
     {
         public LineChartDataset() : base(
             label: string.Empty,
-            backgroundColor: new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) },
-            borderColor: new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) },
+            backgroundColor: new List<string> { ChartColor.FromRgba( 0, 0, 0, 0.1f ) },
+            borderColor: new List<string> { ChartColor.FromRgba( 0, 0, 0, 0.1f ) },
             borderWidth: 3
         )
         { }
@@ -125,13 +125,13 @@ namespace Blazorise.Charts
         /// The fill color for points.
         /// </summary>
         [DataMember( EmitDefaultValue = false )]
-        public List<string> PointBackgroundColor { get; set; } = new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) };
+        public List<string> PointBackgroundColor { get; set; } = new List<string> { ChartColor.FromRgba( 0, 0, 0, 0.1f ) };
 
         /// <summary>
         /// The border color for points.
         /// </summary>
         [DataMember( EmitDefaultValue = false )]
-        public List<string> PointBorderColor { get; set; } = new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) };
+        public List<string> PointBorderColor { get; set; } = new List<string> { ChartColor.FromRgba( 0, 0, 0, 0.1f ) };
 
         /// <summary>
         /// The width of the point border in pixels.
@@ -172,8 +172,8 @@ namespace Blazorise.Charts
     {
         public BarChartDataset() : base(
             label: string.Empty,
-            backgroundColor: new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) },
-            borderColor: new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) },
+            backgroundColor: new List<string> { ChartColor.FromRgba( 0, 0, 0, 0.1f ) },
+            borderColor: new List<string> { ChartColor.FromRgba( 0, 0, 0, 0.1f ) },
             borderWidth: 0
         )
         { }
@@ -183,14 +183,14 @@ namespace Blazorise.Charts
         /// </summary>
         /// <remarks>Default as per https://www.chartjs.org/docs/latest/configuration/elements.html#rectangle-configuration </remarks>
         [DataMember( EmitDefaultValue = false )]
-        public List<string> HoverBackgroundColor { get; set; } = new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) };
+        public List<string> HoverBackgroundColor { get; set; } = new List<string> { ChartColor.FromRgba( 0, 0, 0, 0.1f ) };
 
         /// <summary>
         /// The stroke colour of the bars when hovered.
         /// </summary>
         /// <remarks>Default as per https://www.chartjs.org/docs/latest/configuration/elements.html#rectangle-configuration </remarks>
         [DataMember( EmitDefaultValue = false )]
-        public List<string> HoverBorderColor { get; set; } = new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) };
+        public List<string> HoverBorderColor { get; set; } = new List<string> { ChartColor.FromRgba( 0, 0, 0, 0.1f ) };
 
         /// <summary>
         /// The stroke width of the bars when hovered.
@@ -207,8 +207,8 @@ namespace Blazorise.Charts
     {
         public PieChartDataset() : base(
             label: string.Empty,
-            backgroundColor: new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) },
-            borderColor: new List<string> { ChartColor.FromRgba(0xF, 0xF, 0xF, 1.0f) },
+            backgroundColor: new List<string> { ChartColor.FromRgba( 0, 0, 0, 0.1f ) },
+            borderColor: new List<string> { ChartColor.FromRgba( 0xF, 0xF, 0xF, 1.0f ) },
             borderWidth: 2
         )
         { }
@@ -218,14 +218,14 @@ namespace Blazorise.Charts
         /// </summary>
         /// <remarks>Default as per https://www.chartjs.org/docs/latest/configuration/elements.html#arc-configuration </remarks>
         [DataMember( EmitDefaultValue = false )]
-        public List<string> HoverBackgroundColor { get; set; } = new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) };
+        public List<string> HoverBackgroundColor { get; set; } = new List<string> { ChartColor.FromRgba( 0, 0, 0, 0.1f ) };
 
         /// <summary>
         /// The stroke colour of the arcs when hovered.
         /// </summary>
         /// <remarks>Default as per https://www.chartjs.org/docs/latest/configuration/elements.html#arc-configuration </remarks>
         [DataMember( EmitDefaultValue = false )]
-        public List<string> HoverBorderColor { get; set; } = new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) };
+        public List<string> HoverBorderColor { get; set; } = new List<string> { ChartColor.FromRgba( 0, 0, 0, 0.1f ) };
 
         /// <summary>
         /// The stroke width of the arcs when hovered.
@@ -249,8 +249,8 @@ namespace Blazorise.Charts
     {
         public PolarAreaChartDataset() : base(
             label: string.Empty,
-            backgroundColor: new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) },
-            borderColor: new List<string> { ChartColor.FromRgba(0xF, 0xF, 0xF, 1.0f) },
+            backgroundColor: new List<string> { ChartColor.FromRgba( 0, 0, 0, 0.1f ) },
+            borderColor: new List<string> { ChartColor.FromRgba( 0xF, 0xF, 0xF, 1.0f ) },
             borderWidth: 2
         )
         { }
@@ -260,14 +260,14 @@ namespace Blazorise.Charts
         /// </summary>
         /// <remarks>Default as per https://www.chartjs.org/docs/latest/configuration/elements.html#arc-configuration </remarks>
         [DataMember( EmitDefaultValue = false )]
-        public List<string> HoverBackgroundColor { get; set; } = new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) };
+        public List<string> HoverBackgroundColor { get; set; } = new List<string> { ChartColor.FromRgba( 0, 0, 0, 0.1f ) };
 
         /// <summary>
         /// The stroke colour of the arcs when hovered.
         /// </summary>
         /// <remarks>Default as per https://www.chartjs.org/docs/latest/configuration/elements.html#arc-configuration </remarks>
         [DataMember( EmitDefaultValue = false )]
-        public List<string> HoverBorderColor { get; set; } = new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) };
+        public List<string> HoverBorderColor { get; set; } = new List<string> { ChartColor.FromRgba( 0, 0, 0, 0.1f ) };
 
         /// <summary>
         /// The stroke width of the arcs when hovered.
@@ -285,8 +285,8 @@ namespace Blazorise.Charts
     {
         public RadarChartDataset() : base(
             label: string.Empty,
-            backgroundColor: new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) },
-            borderColor: new List<string> { ChartColor.FromRgba(0, 0, 0, 0.1f) },
+            backgroundColor: new List<string> { ChartColor.FromRgba( 0, 0, 0, 0.1f ) },
+            borderColor: new List<string> { ChartColor.FromRgba( 0, 0, 0, 0.1f ) },
             borderWidth: 3
         )
         { }

--- a/Source/Extensions/Blazorise.Charts/JS.cs
+++ b/Source/Extensions/Blazorise.Charts/JS.cs
@@ -1,5 +1,6 @@
 #region Using directives
 using Microsoft.JSInterop;
+using System.Linq;
 using System.Threading.Tasks;
 #endregion
 
@@ -8,9 +9,9 @@ namespace Blazorise.Charts
     static class JS
     {
         // TODO: clean this
-        public static Task<bool> SetChartData( IJSRuntime runtime, string id, ChartType type, object data, object options )
+        public static Task<bool> SetChartData<TItem, TOptions>( IJSRuntime runtime, string id, ChartType type, ChartData<TItem> data, TOptions options )
         {
-            return runtime.InvokeAsync<bool>( "blazoriseCharts.setChartData", id, ToChartTypeString( type ), data, options, data is string, options is string );
+            return runtime.InvokeAsync<bool>( "blazoriseCharts.setChartData", id, ToChartTypeString( type ), ToChartDataSet( data ), options);
         }
 
         public static string ToChartTypeString( ChartType type )
@@ -31,6 +32,15 @@ namespace Blazorise.Charts
                 default:
                     return "line";
             }
+        }
+
+        private static object ToChartDataSet<T>( ChartData<T> data )
+        {
+            return new
+            {
+                data.Labels,
+                Datasets = data.Datasets.Select( d => d as object ).ToList()
+            };
         }
     }
 }

--- a/Source/Extensions/Blazorise.Charts/JS.cs
+++ b/Source/Extensions/Blazorise.Charts/JS.cs
@@ -39,7 +39,7 @@ namespace Blazorise.Charts
             return new
             {
                 data.Labels,
-                Datasets = data.Datasets.Select( d => d as object ).ToList()
+                Datasets = data.Datasets.ToList<object>()
             };
         }
     }

--- a/Source/Extensions/Blazorise.Charts/JS.cs
+++ b/Source/Extensions/Blazorise.Charts/JS.cs
@@ -9,9 +9,9 @@ namespace Blazorise.Charts
     static class JS
     {
         // TODO: clean this
-        public static Task<bool> SetChartData<TItem, TOptions>( IJSRuntime runtime, string id, ChartType type, ChartData<TItem> data, TOptions options )
+        public static Task<bool> SetChartData<TItem, TOptions>( IJSRuntime runtime, string id, ChartType type, ChartData<TItem> data, TOptions options, string dataJsonString, string optionsJsonString )
         {
-            return runtime.InvokeAsync<bool>( "blazoriseCharts.setChartData", id, ToChartTypeString( type ), ToChartDataSet( data ), options);
+            return runtime.InvokeAsync<bool>( "blazoriseCharts.setChartData", id, ToChartTypeString( type ), ToChartDataSet( data ), options, dataJsonString, optionsJsonString );
         }
 
         public static string ToChartTypeString( ChartType type )

--- a/Source/Extensions/Blazorise.Charts/wwwroot/blazorise.charts.js
+++ b/Source/Extensions/Blazorise.Charts/wwwroot/blazorise.charts.js
@@ -1,11 +1,5 @@
 window.blazoriseCharts = {
-    setChartData: (canvasId, type, data, options, dataIsString, optionsIsString) => {
-        if (dataIsString)
-            data = JSON.parse(data);
-
-        if (optionsIsString)
-            options = JSON.parse(options);
-
+    setChartData: (canvasId, type, data, options) => {
         //console.log(type);
         //console.log(JSON.stringify(data));
         //console.log(JSON.stringify(options));

--- a/Source/Extensions/Blazorise.Charts/wwwroot/blazorise.charts.js
+++ b/Source/Extensions/Blazorise.Charts/wwwroot/blazorise.charts.js
@@ -1,7 +1,7 @@
 window.blazoriseCharts = {
     setChartData: (canvasId, type, data, options, dataJsonString, optionsJsonString) => {
         if (dataJsonString)
-            data = JSON.parse(data);
+            data = JSON.parse(dataJsonString);
 
         if (optionsJsonString)
             options = JSON.parse(optionsJsonString);

--- a/Source/Extensions/Blazorise.Charts/wwwroot/blazorise.charts.js
+++ b/Source/Extensions/Blazorise.Charts/wwwroot/blazorise.charts.js
@@ -1,8 +1,14 @@
 window.blazoriseCharts = {
-    setChartData: (canvasId, type, data, options) => {
+    setChartData: (canvasId, type, data, options, dataJsonString, optionsJsonString) => {
         //console.log(type);
         //console.log(JSON.stringify(data));
         //console.log(JSON.stringify(options));
+
+        if (dataJsonString)
+            data = JSON.parse(data);
+
+        if (optionsJsonString)
+            options = JSON.parse(optionsJsonString);
 
         const chart = blazoriseCharts.getChart(canvasId);
 

--- a/Source/Extensions/Blazorise.Charts/wwwroot/blazorise.charts.js
+++ b/Source/Extensions/Blazorise.Charts/wwwroot/blazorise.charts.js
@@ -1,14 +1,14 @@
 window.blazoriseCharts = {
     setChartData: (canvasId, type, data, options, dataJsonString, optionsJsonString) => {
-        //console.log(type);
-        //console.log(JSON.stringify(data));
-        //console.log(JSON.stringify(options));
-
         if (dataJsonString)
             data = JSON.parse(data);
 
         if (optionsJsonString)
             options = JSON.parse(optionsJsonString);
+
+        //console.log(type);
+        //console.log(JSON.stringify(data));
+        //console.log(JSON.stringify(options));
 
         const chart = blazoriseCharts.getChart(canvasId);
 

--- a/Tests/Blazorise.Demo/Pages/Tests/ChartsPage.razor
+++ b/Tests/Blazorise.Demo/Pages/Tests/ChartsPage.razor
@@ -16,7 +16,7 @@
         <Card Margin="Margin.Is4.OnY">
             <CardHeader>
                 <CardTitle>Bar</CardTitle>
-                <SimpleButton Clicked="@(async () => await HandleRedraw( barChart, GetChartDataset ))">Redraw</SimpleButton>
+                <SimpleButton Clicked="@(async () => await HandleRedraw( barChart, GetBarChartDataset ))">Redraw</SimpleButton>
             </CardHeader>
             <CardBody>
                 <Chart @ref="barChart" Type="ChartType.Bar" TItem="double" />
@@ -27,7 +27,7 @@
         <Card Margin="Margin.Is4.OnY">
             <CardHeader>
                 <CardTitle>Pie</CardTitle>
-                <SimpleButton Clicked="@(async () => await HandleRedraw( pieChart, GetChartDataset ))">Redraw</SimpleButton>
+                <SimpleButton Clicked="@(async () => await HandleRedraw( pieChart, GetPieChartDataset ))">Redraw</SimpleButton>
             </CardHeader>
             <CardBody>
                 <Chart @ref="pieChart" Type="ChartType.Pie" TItem="double" />
@@ -40,7 +40,7 @@
         <Card Margin="Margin.Is4.FromBottom">
             <CardHeader>
                 <CardTitle>Polar Area</CardTitle>
-                <SimpleButton Clicked="@(async () => await HandleRedraw( polarAreaChart, GetChartDataset ))">Redraw</SimpleButton>
+                <SimpleButton Clicked="@(async () => await HandleRedraw( polarAreaChart, GetPolarAreaChartDataset ))">Redraw</SimpleButton>
             </CardHeader>
             <CardBody>
                 <Chart @ref="polarAreaChart" Type="ChartType.PolarArea" TItem="double" />
@@ -62,7 +62,7 @@
         <Card Margin="Margin.Is4.FromBottom">
             <CardHeader>
                 <CardTitle>Doughnut</CardTitle>
-                <SimpleButton Clicked="@(async () => await HandleRedraw( doughnutChart, GetChartDataset ))">Redraw</SimpleButton>
+                <SimpleButton Clicked="@(async () => await HandleRedraw( doughnutChart, GetDoughnutChartDataset ))">Redraw</SimpleButton>
             </CardHeader>
             <CardBody>
                 <Chart @ref="doughnutChart" Type="ChartType.Doughnut" TItem="double" />
@@ -92,10 +92,10 @@
 
             await Task.WhenAll(
                 HandleRedraw( lineChart, GetLineChartDataset ),
-                HandleRedraw( barChart, GetChartDataset ),
-                HandleRedraw( pieChart, GetChartDataset ),
-                HandleRedraw( doughnutChart, GetChartDataset ),
-                HandleRedraw( polarAreaChart, GetChartDataset ),
+                HandleRedraw( barChart, GetBarChartDataset ),
+                HandleRedraw( pieChart, GetPieChartDataset ),
+                HandleRedraw( doughnutChart, GetDoughnutChartDataset ),
+                HandleRedraw( polarAreaChart, GetPolarAreaChartDataset ),
                 HandleRedraw( radarChart, GetRadarChartDataset ) );
         }
     }
@@ -133,10 +133,7 @@
             BackgroundColor = backgroundColors,
             BorderColor = borderColors,
             Fill = true,
-            PointRadius = 2,
-            //LineTension = 1,
-            BorderDash = new List<int> { },
-            SteppedLine = true
+            SteppedLine = false
         };
     }
 

--- a/Tests/Blazorise.Demo/Pages/Tests/ChartsPage.razor
+++ b/Tests/Blazorise.Demo/Pages/Tests/ChartsPage.razor
@@ -135,7 +135,8 @@
             Fill = true,
             PointRadius = 2,
             //LineTension = 1,
-            BorderDash = new List<int> { }
+            BorderDash = new List<int> { },
+            SteppedLine = true
         };
     }
 

--- a/Tests/Blazorise.Demo/Pages/Tests/ChartsPage.razor
+++ b/Tests/Blazorise.Demo/Pages/Tests/ChartsPage.razor
@@ -120,7 +120,7 @@
             Label = "# of randoms",
             Data = RandomizeData(),
             BackgroundColor = backgroundColors,
-            BorderColor = borderColors,
+            BorderColor = borderColors
         };
     }
 
@@ -133,7 +133,9 @@
             BackgroundColor = backgroundColors,
             BorderColor = borderColors,
             Fill = true,
-            SteppedLine = false
+            PointRadius = 3,
+            BorderWidth = 1,
+            PointBorderColor = Enumerable.Repeat(borderColors.First(), 6).ToList()
         };
     }
 
@@ -145,6 +147,7 @@
             Data = RandomizeData(),
             BackgroundColor = backgroundColors,
             BorderColor = borderColors,
+            BorderWidth = 1
         };
     }
 
@@ -157,6 +160,7 @@
             Data = RandomizeData(),
             BackgroundColor = backgroundColors,
             BorderColor = borderColors,
+            BorderWidth = 1
         };
     }
 
@@ -168,6 +172,7 @@
             Data = RandomizeData(),
             BackgroundColor = backgroundColors,
             BorderColor = borderColors,
+            BorderWidth = 1
         };
     }
 
@@ -179,6 +184,7 @@
             Data = RandomizeData(),
             BackgroundColor = backgroundColors,
             BorderColor = borderColors,
+            BorderWidth = 1
         };
     }
 
@@ -190,8 +196,8 @@
             Data = RandomizeData(),
             BackgroundColor = backgroundColors,
             BorderColor = borderColors,
-            Fill = false,
-            LineTension = 0.5f
+            LineTension = 0.0f,
+            BorderWidth = 1
         };
     }
 

--- a/docs/_docs/extensions/chart.md
+++ b/docs/_docs/extensions/chart.md
@@ -9,6 +9,10 @@ toc_label: "Guide"
 **Warning:** Right now there are some issues when serializing dataset object to json. Blazor internal serializer is serializing nullable fields and when ChartJS is trying to read them it will break. There is not much I can do for now, except to always inititalise all of the fields for the particular chart dataset.
 {: .notice--warning}
 
+**Update:** As of version **0.5.2** and **0.6.0-preview3** there are now two parameters for the chart components that will serve as a workaround for Blazor serializer which does not supports DataContract and DataMember attributes. The new parameters are `DataJsonString` and `OptionsJsonString` and are used to provide data and options for charts as json strings.
+Keep in mind that these two parameters are just a temporary feature that will be removed once the Blazor team implements a better serializer.
+{: .notice--info}
+
 ## Basics
 
 The chart extension is defined of several different chart components. Each of the chart type have it's own dataset and option settings.
@@ -112,3 +116,8 @@ You should always define `TItem` data type.
 | Type               | [ChartType]({{ "/docs/helpers/enums/#charttype" | relative_url }})         | `Line`       | Defines the chart type.                                                               |
 | Data               | ChartData                                                                  |              | Defines the chart data.                                                               |
 | Options            | ChartOptions                                                               |              | Defines the chart options.                                                            |
+| DataJsonString     | string                                                                     | null         | Defines the chart data that is serialized as json string. **[WILL BE REMOVED]**       |
+| OptionsJsonString  | string                                                                     | null         | Defines the chart options that is serialized as json string. **[WILL BE REMOVED]**    |
+
+**Note:** DataJsonString and OptionsJsonString are used only temporary until the Blazor team fixes the built-in json serializer.
+{: .notice--info}

--- a/docs/_docs/extensions/chart.md
+++ b/docs/_docs/extensions/chart.md
@@ -9,10 +9,6 @@ toc_label: "Guide"
 **Warning:** Right now there are some issues when serializing dataset object to json. Blazor internal serializer is serializing nullable fields and when ChartJS is trying to read them it will break. There is not much I can do for now, except to always inititalise all of the fields for the particular chart dataset.
 {: .notice--warning}
 
-**Update:** As of version **0.5.2** and **0.6.0-preview3** there are now two parameters for the chart components that will serve as a workaround for Blazor serializer which does not supports DataContract and DataMember attributes. The new parameters are `DataJsonString` and `OptionsJsonString` and are used to provide data and options for charts as json strings.
-Keep in mind that these two parameters are just a temporary feature that will be removed once the Blazor team implements a better serializer.
-{: .notice--info}
-
 ## Basics
 
 The chart extension is defined of several different chart components. Each of the chart type have it's own dataset and option settings.
@@ -116,8 +112,3 @@ You should always define `TItem` data type.
 | Type               | [ChartType]({{ "/docs/helpers/enums/#charttype" | relative_url }})         | `Line`       | Defines the chart type.                                                               |
 | Data               | ChartData                                                                  |              | Defines the chart data.                                                               |
 | Options            | ChartOptions                                                               |              | Defines the chart options.                                                            |
-| DataJsonString     | string                                                                     | null         | Defines the chart data that is serialized as json string. **[WILL BE REMOVED]**       |
-| OptionsJsonString  | string                                                                     | null         | Defines the chart options that is serialized as json string. **[WILL BE REMOVED]**    |
-
-**Note:** DataJsonString and OptionsJsonString are used only temporary until the Blazor team fixes the built-in json serializer.
-{: .notice--info}


### PR DESCRIPTION
It seems that one of the Blazor Json Serialization limitations is that it strictly limits properties to the declared `<T>` data types in `List<T>` and not looking at runtime subclasses of `T`.
This pull request works around that limitation.

For `ChartData<TItem>` by casting the `List<ChartDataset<TItem>> Datasets` to` List<object>` which happily serializes `TItem` properties and `TItem` subclass properties.
Unhappily, it does not honor `EmitDefaultValue = false` attribute instructions in this way. I investigated casting to specific ChartDataset subclasses however found that the codebase did not always honor the correct use of `ChartDataset` subclass for each graph type, so I was not sure if that was a design intention to accept it. (This can be revisited if you are OK for the PR to enforce that, for example, line charts must always have `List<LineChartDataset<TItem>> Datasets`)
As a result, I had to provide default options for all chart dataset properties as per your chart.md comment.
For the defaults I chose the default values from the chartjs website. These dont always have the best/consistent UX look to them, but were (for me) a better choice than arbitrarily choosing "looks good" values.

For `ChartOptions` a signature change to `Blazorise.Charts.JS.SetChartData` was sufficient to obtain correct serialization.

During testing I found that `BorderDashOffset` and `LineTension` were incorrectly specified as Int rather than the required Float, as their values can range between 0-1.