### PR TITLE
Rename Server-side and Client-side Blazor

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Blazorise is a component library built on top of [Blazor](https://blazor.net/) a
 
 ## Demos
 
-### Client-Side Blazor
+### Blazor WebAssembly
 
 - [Bootstrap Demo](https://bootstrapdemo.blazorise.com)
 - [Material Demo](https://materialdemo.blazorise.com/)
 - [Bulma Demo](https://bulmademo.blazorise.com/)
 - [eFrolic Demo](https://efrolicdemo.blazorise.com/)
 
-### Server-Side Blazor
+### Blazor Server
 
 - [Bootstrap Demo](https://rcbootstrapdemo.blazorise.com/)
 
@@ -112,7 +112,7 @@ public void ConfigureServices( IServiceCollection services )
 }
 ```
 
-### Client-Side
+### Blazor WebAssembly
 
 ```cs
 public void Configure( IComponentsApplicationBuilder app )
@@ -125,7 +125,7 @@ public void Configure( IComponentsApplicationBuilder app )
 }
 ```
 
-### Server-Side
+### Blazor Server
 
 ```cs
 public void Configure( IComponentsApplicationBuilder app )
@@ -146,7 +146,7 @@ public void Configure( IComponentsApplicationBuilder app )
 }
 ```
 
-This step is mandatory only for projects built on top of Server-Side Blazor(Razor Components)! For Client-Side Blazor projects this step is not required! Normally these files would be downloaded automatically by the framework but since Razor Components still doesn't support static files inside of class library you will need to manually include required js and css files into your project. Once the Blazor/RC team implements this feature this step will not we required.
+This step is mandatory only for projects built on top of Blazor Server(Razor Components)! For Blazor WebAssembly projects this step is not required! Normally these files would be downloaded automatically by the framework but since Razor Components still doesn't support static files inside of class library you will need to manually include required js and css files into your project. Once the Blazor/RC team implements this feature this step will not we required.
 
 First you must download **bundle.zip** from the [release](https://github.com/stsrki/Blazorise/releases) tab and extract it to your _wwwroot_ folder. After extraction you will have to include files in your Index.cshtml eg.
 

--- a/docs/_docs/start.md
+++ b/docs/_docs/start.md
@@ -79,7 +79,7 @@ public void ConfigureServices( IServiceCollection services )
 }
 ```
 
-### Client-Side
+### Blazor WebAssembly
 
 ```
 public void Configure( IComponentsApplicationBuilder app )
@@ -92,7 +92,7 @@ public void Configure( IComponentsApplicationBuilder app )
 }
 ```
 
-### Server-Side
+### Blazor Server
 
 ```
 public void Configure( IComponentsApplicationBuilder app )

--- a/docs/_docs/usage/bootstrap.md
+++ b/docs/_docs/usage/bootstrap.md
@@ -73,7 +73,7 @@ public void ConfigureServices( IServiceCollection services )
 }
 ```
 
-### Client-Side
+### Blazor WebAssembly
 
 ```
 public void Configure( IComponentsApplicationBuilder app )
@@ -86,7 +86,7 @@ public void Configure( IComponentsApplicationBuilder app )
 }
 ```
 
-### Server-Side
+### Blazor Server
 
 ```
 public void Configure( IComponentsApplicationBuilder app )

--- a/docs/_docs/usage/bulma.md
+++ b/docs/_docs/usage/bulma.md
@@ -70,7 +70,7 @@ public void ConfigureServices( IServiceCollection services )
 }
 ```
 
-### Client-Side
+### Blazor WebAssembly
 
 ```
 public void Configure( IComponentsApplicationBuilder app )
@@ -83,7 +83,7 @@ public void Configure( IComponentsApplicationBuilder app )
 }
 ```
 
-### Server-Side
+### Blazor Server
 
 ```
 public void Configure( IComponentsApplicationBuilder app )

--- a/docs/_docs/usage/material.md
+++ b/docs/_docs/usage/material.md
@@ -89,7 +89,7 @@ public void ConfigureServices( IServiceCollection services )
 }
 ```
 
-### Client-Side
+### Blazor WebAssembly
 
 ```
 public void Configure( IComponentsApplicationBuilder app )
@@ -102,7 +102,7 @@ public void Configure( IComponentsApplicationBuilder app )
 }
 ```
 
-### Server-Side
+### Blazor Server
 
 ```
 public void Configure( IComponentsApplicationBuilder app )


### PR DESCRIPTION
With Blazor/Core Preview 8, the terms used to describe Server-side and Client-side Blazor changed to Blazor Server and Blazor WebAssembly, respectively. 

[ASP.NET Core and Blazor updates in .NET Core 3.0 Preview 8](https://devblogs.microsoft.com/aspnet/asp-net-core-and-blazor-updates-in-net-core-3-0-preview-8/)
[Introduction to Blazor](https://docs.microsoft.com/en-us/aspnet/core/blazor/?view=aspnetcore-3.0)

After Blazor Server officially launches this month, new interested users may be thrown off if the terminology is different here than in official documentation.

This change updates the Readme and docs to use those terms instead.