### PR TITLE
Fix so that Autocomplete dropdown doesn't show empty dropdown

### DIFF
--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -40,7 +40,7 @@ namespace Blazorise.Components
             CurrentSearch = text ?? string.Empty;
             dirtyFilter = true;
 
-            if ( text?.Length >= MinLength )
+            if ( text?.Length >= MinLength && FilteredData.Any())
                 dropdownRef.Open();
             else
                 dropdownRef.Close();

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -1,4 +1,4 @@
-﻿#region Using directives
+#region Using directives
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -40,7 +40,7 @@ namespace Blazorise.Components
             CurrentSearch = text ?? string.Empty;
             dirtyFilter = true;
 
-            if ( text?.Length >= MinLength && FilteredData.Any())
+            if ( text?.Length >= MinLength && FilteredData.Any() )
                 dropdownRef.Open();
             else
                 dropdownRef.Close();


### PR DESCRIPTION
Fixed up autocomplete show that the dropdown menu is only displayed when there is FilteredData available.