### PR TITLE
Chart Options Not Updating

### DIFF
--- a/Source/Extensions/Blazorise.Charts/wwwroot/blazorise.charts.js
+++ b/Source/Extensions/Blazorise.Charts/wwwroot/blazorise.charts.js
@@ -55,8 +55,8 @@ window.blazoriseCharts = {
         const chart = window.blazoriseCharts.getChart(canvasId);
 
         if (chart) {
-            chart.config.data = data;
-            chart.config.options = options;
+            chart.data = data;
+            chart.options = options;
             chart.update();
         }
 


### PR DESCRIPTION
If you made a change to any of the chart options after the initial render they were not getting applied. Data changes were.

Changing the lines in the update method to not include config fixed this.