### PR TITLE
feat: added attribute VisibleCharacters to TextEdit

### DIFF
--- a/Source/Blazorise.Bulma/TextEdit.razor
+++ b/Source/Blazorise.Bulma/TextEdit.razor
@@ -3,7 +3,7 @@
 {
     <div class="field">
         <div class="control">
-            <input @ref="ElementRef" id="@ElementId" type="@Type" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@IsDisabled" readonly="@IsReadonly" maxlength="@MaxLength" pattern="@Pattern" value="@Text" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@KeyDown" @onkeypress="@KeyPress" @onkeyup="KeyUp" />
+            <input @ref="ElementRef" id="@ElementId" type="@Type" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@IsDisabled" readonly="@IsReadonly" maxlength="@MaxLength" size="@VisibleCharacters" pattern="@Pattern" value="@Text" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@KeyDown" @onkeypress="@KeyPress" @onkeyup="KeyUp" />
             @ChildContent
         </div>
         @Feedback
@@ -12,7 +12,7 @@
 else
 {
     <div class="control">
-        <input @ref="ElementRef" id="@ElementId" type="@Type" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@IsDisabled" readonly="@IsReadonly" maxlength="@MaxLength" pattern="@Pattern" value="@Text" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@KeyDown" @onkeypress="@KeyPress" @onkeyup="KeyUp" />
+        <input @ref="ElementRef" id="@ElementId" type="@Type" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@IsDisabled" readonly="@IsReadonly" maxlength="@MaxLength" size="@VisibleCharacters" pattern="@Pattern" value="@Text" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@KeyDown" @onkeypress="@KeyPress" @onkeyup="KeyUp" />
         @ChildContent
     </div>
     @Feedback

--- a/Source/Blazorise/TextEdit.razor
+++ b/Source/Blazorise/TextEdit.razor
@@ -2,7 +2,7 @@
 @inherits Blazorise.BaseTextEdit
 @if ( !HasCustomRegistration )
 {
-    <input @ref="ElementRef" id="@ElementId" type="@Type" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@IsDisabled" readonly="@IsReadonly" maxlength="@MaxLength" pattern="@Pattern" value="@CurrentValue" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@KeyDown" @onkeypress="@KeyPress" @onkeyup="KeyUp" />
+    <input @ref="ElementRef" id="@ElementId" type="@Type" inputmode="@Mode" class="@ClassNames" style="@StyleNames" placeholder="@Placeholder" disabled="@IsDisabled" readonly="@IsReadonly" maxlength="@MaxLength" size="@VisibleCharacters" pattern="@Pattern" value="@CurrentValue" @onchange="@OnChangeHandler" @oninput="@OnInputHandler" @onkeydown="@KeyDown" @onkeypress="@KeyPress" @onkeyup="KeyUp" />
     @ChildContent
     @Feedback
 }

--- a/Source/Blazorise/TextEdit.razor.cs
+++ b/Source/Blazorise/TextEdit.razor.cs
@@ -118,6 +118,12 @@ namespace Blazorise
         /// </summary>
         [Parameter] public int? MaxLength { get; set; }
 
+        /// <summary>
+        /// The size attribute specifies the visible width, in characters, of an <input> element.
+        /// </summary>
+        /// <see cref="https://www.w3schools.com/tags/att_input_size.asp"/>
+        [Parameter] public int? VisibleCharacters { get; set; }
+
         #endregion
     }
 }


### PR DESCRIPTION
Added `VisibleCharacters` attribute to the `TextEdit` component. It is used as an abstraction over `size` attribute on native `<input>` element