### PR TITLE
fix: Autocomplete no longer works in 0.8.7

### DIFF
--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -38,6 +38,7 @@ namespace Blazorise.Components
         protected void HandleTextChanged( string text )
         {
             CurrentSearch = text ?? string.Empty;
+            SelectedText = CurrentSearch;
             dirtyFilter = true;
 
             if ( text?.Length >= MinLength && FilteredData.Any() )


### PR DESCRIPTION
The reason for bug was that `TextEdit` was working wrong in previous versions of Blazorise. After refactoring in 0.8.7 the behavior has changed but I didn't update Autocomplete.