### PR TITLE
fix: DataGrid RowRemoved called even if RowRemoving was canceled

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -164,11 +164,11 @@ namespace Blazorise.DataGrid
                         if ( data.Contains( item ) )
                             data.Remove( item );
                     }
+
+                    await RowRemoved.InvokeAsync( item );
+
+                    dirtyFilter = dirtyView = true;
                 }
-
-                await RowRemoved.InvokeAsync( item );
-
-                dirtyFilter = dirtyView = true;
             }
         }
 


### PR DESCRIPTION
#326 