### PR TITLE
Sidebar items can be expanded by default when using the dynamic method

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -1,0 +1,17 @@
+name: .NET Core
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.100
+    - name: Build with dotnet
+      run: dotnet build Blazorise.sln --configuration Release

--- a/Source/Extensions/Blazorise.Sidebar/Sidebar.razor
+++ b/Source/Extensions/Blazorise.Sidebar/Sidebar.razor
@@ -15,12 +15,12 @@
                     @foreach ( var item in Data.Items )
                     {
                         <SidebarItem @key="@item">
-                            <SidebarLink To="@item.To" Title="@item.Tooltip" Toggled="@((isOpen)=>{item.SubItemReference?.Toggle( isOpen );})">
+                            <SidebarLink To="@item.To" Title="@item.Tooltip" IsShow="@item.IsShow" Toggled="@((isOpen)=>{item.SubItemReference?.Toggle( isOpen );})">
                                 @item.Text
                             </SidebarLink>
                             @if ( item.SubItems != null )
                             {
-                                <SidebarSubItem @ref="item.SubItemReference">
+                                <SidebarSubItem @ref="item.SubItemReference" IsShow="@item.IsShow">
                                     @foreach ( var subItem in item.SubItems )
                                     {
                                         <SidebarItem @key="@subItem">

--- a/Source/Extensions/Blazorise.Sidebar/SidebarData.cs
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarData.cs
@@ -68,6 +68,12 @@ namespace Blazorise.Sidebar
         public string To { get; set; }
 
         /// <summary>
+        /// Whether the item and all sub-items are shown.
+        /// </summary>
+        [DataMember( EmitDefaultValue = false )]
+        public bool IsShow { get; set; }
+
+        /// <summary>
         /// Collection of item sub-items.
         /// </summary>
         [DataMember( EmitDefaultValue = false )]


### PR DESCRIPTION
When using the Sidebar extension I wanted to use the dynamic approach because it seemed more flexible. Then I found out that items are collapsed by default. I ended up having to reimplement the logic from Sidebar.razor to add this option.

This commit adds exactly that option. The SidebarItemInfo has a new property which will expand it and all sub-items. The toggling still works no matter in which state the items start.

I think Blazorise is a fantastic library and I look forward to contributing more.