### PR TITLE
feat: added SortDirection.None for DataGrid

### DIFF
--- a/Source/Blazorise/Enums.cs
+++ b/Source/Blazorise/Enums.cs
@@ -1201,14 +1201,19 @@ namespace Blazorise
     public enum SortDirection
     {
         /// <summary>
+        /// No sorting will be applied.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
         /// Sorts in ascending order.
         /// </summary>
-        Ascending = 0,
+        Ascending = 1,
 
         /// <summary>
         /// Sorts in descending order.
         /// </summary>
-        Descending = 1,
+        Descending = 2,
     }
 
     /// <summary>

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -29,7 +29,7 @@
                                 {
                                     @column.Caption
                                 }
-                                @if ( Sortable && column.Sortable )
+                                @if ( Sortable && column.Sortable && column.Direction != SortDirection.None )
                                 {
                                     <Icon Name="@(column.Direction == SortDirection.Descending ? IconName.SortDown : IconName.SortUp)" />
                                 }

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -282,17 +282,22 @@ namespace Blazorise.DataGrid
         {
             if ( Sortable && column.Sortable )
             {
-                column.Direction = column.Direction == SortDirection.Descending ? SortDirection.Ascending : SortDirection.Descending;
-                sortByColumn = column;
+                column.Direction = column.Direction.NextDirection();
 
-                // just one column can be sorted for now!
-                foreach ( var col in Columns )
+                // When using internal sorting just one column can be sorted!
+                // TODO: planned for 0.9 to enable sorting for all columns
+                if ( !ReadData.HasDelegate )
                 {
-                    if ( col.ElementId == column.ElementId )
-                        continue;
+                    sortByColumn = column;
 
-                    // reset all others
-                    col.Direction = SortDirection.Ascending;
+                    foreach ( var col in Columns )
+                    {
+                        if ( col.ElementId == column.ElementId )
+                            continue;
+
+                        // reset all others
+                        col.Direction = SortDirection.None;
+                    }
                 }
 
                 dirtyFilter = dirtyView = true;
@@ -379,7 +384,7 @@ namespace Blazorise.DataGrid
                 {
                     if ( sortByColumn.Direction == SortDirection.Descending )
                         query = query.OrderByDescending( item => sortByColumn.GetValue( item ) );
-                    else
+                    else if ( sortByColumn.Direction == SortDirection.Ascending )
                         query = query.OrderBy( item => sortByColumn.GetValue( item ) );
                 }
 

--- a/Source/Extensions/Blazorise.DataGrid/ExtensionMethods.cs
+++ b/Source/Extensions/Blazorise.DataGrid/ExtensionMethods.cs
@@ -1,0 +1,32 @@
+﻿#region Using directives
+using System;
+using System.Collections.Generic;
+using System.Text;
+#endregion
+
+namespace Blazorise.DataGrid
+{
+    /// <summary>
+    /// Helper extension methods.
+    /// </summary>
+    public static class ExtensionMethods
+    {
+        /// <summary>
+        /// Gets the next available direction based on the current one.
+        /// </summary>
+        /// <param name="direction">Current sort direction.</param>
+        /// <returns>Returns the next available sort direction.</returns>
+        public static SortDirection NextDirection( this SortDirection direction )
+        {
+            switch ( direction )
+            {
+                case SortDirection.None:
+                    return SortDirection.Ascending;
+                case SortDirection.Ascending:
+                    return SortDirection.Descending;
+                default:
+                    return SortDirection.None;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added `SortDirection.None` to enable custom sorting on `ReadData` event handler.

@ricardoromaobr Can you please confirm on your side this is working?