### PR TITLE
feat: CloseReason for closable components like Modal, Dropdown, etc.

### DIFF
--- a/Source/Blazorise/Adapters/CloseActivatorAdapter.cs
+++ b/Source/Blazorise/Adapters/CloseActivatorAdapter.cs
@@ -27,15 +27,28 @@ namespace Blazorise
         }
 
         [JSInvokable()]
-        public bool SafeToClose( string elementId, bool isEscapeKey )
+        public bool SafeToClose( string elementId, string reason )
         {
-            return component.SafeToClose( elementId, isEscapeKey );
+            return component.IsSafeToClose( elementId, GetCloseReason( reason ) );
         }
 
         [JSInvokable()]
-        public void Close()
+        public void Close( string reason )
         {
-            component.Close();
+            component.Close( GetCloseReason( reason ) );
+        }
+
+        private static CloseReason GetCloseReason( string reason )
+        {
+            switch ( reason )
+            {
+                case "leave":
+                    return CloseReason.FocusLostClosing;
+                case "escape":
+                    return CloseReason.EscapeClosing;
+                default:
+                    return CloseReason.None;
+            }
         }
     }
 }

--- a/Source/Blazorise/BarDropdownToggle.razor.cs
+++ b/Source/Blazorise/BarDropdownToggle.razor.cs
@@ -76,12 +76,12 @@ namespace Blazorise
             ParentBarDropdown?.Toggle();
         }
 
-        public bool SafeToClose( string elementId, bool isEscapeKey )
+        public bool IsSafeToClose( string elementId, CloseReason closeReason )
         {
-            return isEscapeKey || elementId != ElementId;
+            return closeReason == CloseReason.EscapeClosing || elementId != ElementId;
         }
 
-        public void Close()
+        public void Close( CloseReason closeReason )
         {
             ParentBarDropdown?.Hide();
         }

--- a/Source/Blazorise/DropdownToggle.razor.cs
+++ b/Source/Blazorise/DropdownToggle.razor.cs
@@ -77,12 +77,12 @@ namespace Blazorise
             ParentDropdown?.Toggle();
         }
 
-        public bool SafeToClose( string elementId, bool isEscapeKey )
+        public bool IsSafeToClose( string elementId, CloseReason closeReason )
         {
-            return isEscapeKey || elementId != ElementId;
+            return closeReason == CloseReason.EscapeClosing || elementId != ElementId;
         }
 
-        public void Close()
+        public void Close( CloseReason closeReason )
         {
             ParentDropdown?.Hide();
         }

--- a/Source/Blazorise/Enums.cs
+++ b/Source/Blazorise/Enums.cs
@@ -1318,4 +1318,30 @@ namespace Blazorise
         /// </summary>
         File,
     }
+
+    /// <summary>
+    /// Specifies the reason that a component was closed.
+    /// </summary>
+    public enum CloseReason
+    {
+        /// <summary>
+        /// The cause of the closure was not defined or could not be determined.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// The user is closing the component through the user interface.
+        /// </summary>
+        UserClosing,
+
+        /// <summary>
+        /// The component has lost focus or user has gone out of bounds.
+        /// </summary>
+        FocusLostClosing,
+
+        /// <summary>
+        /// Pressing the escape key is closing the component.
+        /// </summary>
+        EscapeClosing,
+    }
 }

--- a/Source/Blazorise/EventArguments.cs
+++ b/Source/Blazorise/EventArguments.cs
@@ -9,24 +9,21 @@ using System.Threading.Tasks;
 
 namespace Blazorise
 {
-    public class ChangingEventArgs : CancelEventArgs
+    /// <summary>
+    /// Provides data for the <see cref="Modal.Closing"/> event.
+    /// </summary>
+    public class ModalClosingEventArgs : CancelEventArgs
     {
-        public ChangingEventArgs( string oldValue, string newValue )
+        public ModalClosingEventArgs( bool cancel, CloseReason closeReason )
+            : base( cancel )
         {
-            OldValue = oldValue;
-            NewValue = newValue;
+            CloseReason = closeReason;
         }
 
-        public ChangingEventArgs( string oldValue, string newValue, bool cancel )
-        {
-            OldValue = oldValue;
-            NewValue = newValue;
-            Cancel = cancel;
-        }
-
-        public string OldValue { get; set; }
-
-        public string NewValue { get; set; }
+        /// <summary>
+        /// Gets a value that indicates why the modal is being closed.
+        /// </summary>
+        public CloseReason CloseReason { get; }
     }
 
     public class ValidatingAllEventArgs : CancelEventArgs

--- a/Source/Blazorise/ICloseActivator.cs
+++ b/Source/Blazorise/ICloseActivator.cs
@@ -21,12 +21,14 @@ namespace Blazorise
         /// Finds if the closable component is ready to be closed.
         /// </summary>
         /// <param name="elementId">Currently clicked element id.</param>
+        /// <param name="closeReason">The reason for closing the component.</param>
         /// <returns>Returns true if the closable component is ready to be closed.</returns>
-        bool SafeToClose( string elementId, bool isEscapeKey );
+        bool IsSafeToClose( string elementId, CloseReason closeReason );
 
         /// <summary>
         /// Triggers the closable component to be closed.
         /// </summary>
-        void Close();
+        /// <param name="closeReason">The reason for closing the component.</param>
+        void Close( CloseReason closeReason );
     }
 }

--- a/Source/Blazorise/ModalBackdrop.razor.cs
+++ b/Source/Blazorise/ModalBackdrop.razor.cs
@@ -74,15 +74,14 @@ namespace Blazorise
             base.BuildClasses( builder );
         }
 
-        public bool SafeToClose( string elementId, bool isEscapeKey )
+        public bool IsSafeToClose( string elementId, CloseReason closeReason )
         {
-            // TODO: ask for parent modal is it OK to close it
             return ElementId == elementId;
         }
 
-        public void Close()
+        public void Close( CloseReason closeReason )
         {
-            ParentModal?.Hide();
+            ParentModal?.Hide( closeReason );
         }
 
         private void OnModalStateChanged( object sender, ModalStateEventArgs e )

--- a/Source/Blazorise/wwwroot/blazorise.js
+++ b/Source/Blazorise/wwwroot/blazorise.js
@@ -136,7 +136,7 @@ window.blazorise = {
 
     tryClose: (closable, targetElementId, isEscapeKey) => {
         let request = new Promise((resolve, reject) => {
-            closable.dotnetAdapter.invokeMethodAsync('SafeToClose', targetElementId, isEscapeKey)
+            closable.dotnetAdapter.invokeMethodAsync('SafeToClose', targetElementId, isEscapeKey ? 'escape' : 'leave')
                 .then((result) => resolve({ elementId: closable.elementId, dotnetAdapter: closable.dotnetAdapter, status: result === true ? 'ok' : 'cancelled' }))
                 .catch(() => resolve({ elementId: closable.elementId, status: 'error' }));
         });
@@ -145,7 +145,7 @@ window.blazorise = {
             request
                 .then((response) => {
                     if (response.status === 'ok') {
-                        response.dotnetAdapter.invokeMethodAsync('Close')
+                        response.dotnetAdapter.invokeMethodAsync('Close', isEscapeKey ? 'escape' : 'leave')
                             // If the user navigates to another page then it will raise exception because the reference to the component cannot be found.
                             // In that case just remove the elementId from the list.
                             .catch(() => window.blazorise.unregisterClosableComponent(response.elementId));


### PR DESCRIPTION
#549 

Added `CloseReason` enum to the modal `Closing` event which can be used for better control over stopping modal from closing.