### PR TITLE
feat: File upload

### DIFF
--- a/Source/Blazorise.Bootstrap/FileEdit.razor
+++ b/Source/Blazorise.Bootstrap/FileEdit.razor
@@ -1,6 +1,6 @@
 ﻿@inherits Blazorise.FileEdit
 <Control Role="ControlRole.File">
-    <input id="@ElementId" @ref="@ElementRef" type="file" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" multiple="@Multiple" accept="@Filter" @onchange="@OnChangeHandler" @attributes="@Attributes" />
+    <input @ref="@ElementRef" id="@ElementId" type="file" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" multiple="@Multiple" accept="@Filter" @attributes="@Attributes" />
     <Label Type="LabelType.File" For="@ElementId">@ChildContent</Label>
 </Control>
 @ChildContent

--- a/Source/Blazorise.Bulma/FileEdit.razor
+++ b/Source/Blazorise.Bulma/FileEdit.razor
@@ -1,7 +1,7 @@
 ﻿@inherits Blazorise.FileEdit
 <Control Role="ControlRole.File">
     <Label Type="LabelType.File" For="@ElementId">
-        <input id="@ElementId" type="file" class="@ClassNames" disabled="@Disabled" readonly="@ReadOnly" multiple="@Multiple" accept="@Filter" @onchange="@OnChangeHandler" @attributes="@Attributes" />
+        <input @ref="@ElementRef" id="@ElementId" type="file" class="@ClassNames" disabled="@Disabled" readonly="@ReadOnly" multiple="@Multiple" accept="@Filter" @attributes="@Attributes" />
         @ChildContent
         <span class="file-cta">
             <span class="file-label">

--- a/Source/Blazorise/Adapters/FileEditAdapter.cs
+++ b/Source/Blazorise/Adapters/FileEditAdapter.cs
@@ -1,0 +1,29 @@
+﻿#region Using directives
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.JSInterop;
+#endregion
+
+namespace Blazorise
+{
+    /// <summary>
+    /// Middleman between the FileEdit component and javascript.
+    /// </summary>
+    public class FileEditAdapter
+    {
+        private readonly IFileEdit fileEdit;
+
+        public FileEditAdapter( IFileEdit fileEdit )
+        {
+            this.fileEdit = fileEdit;
+        }
+
+        [JSInvokable]
+        public Task NotifyChange( FileEntry[] files )
+        {
+            return fileEdit.NotifyChange( files );
+        }
+    }
+}

--- a/Source/Blazorise/EventArguments.cs
+++ b/Source/Blazorise/EventArguments.cs
@@ -308,11 +308,17 @@ namespace Blazorise
     /// </summary>
     public class FileWrittenEventArgs : EventArgs
     {
-        public FileWrittenEventArgs( long position, byte[] data )
+        public FileWrittenEventArgs( IFileEntry file, long position, byte[] data )
         {
+            File = file;
             Position = position;
             Data = data;
         }
+
+        /// <summary>
+        /// Gets the file currently being uploaded.
+        /// </summary>
+        public IFileEntry File { get; }
 
         /// <summary>
         /// Gets the current position offset based on the original data source.
@@ -330,10 +336,16 @@ namespace Blazorise
     /// </summary>
     public class FileProgressedEventArgs : EventArgs
     {
-        public FileProgressedEventArgs( double progress )
+        public FileProgressedEventArgs( IFileEntry file, double progress )
         {
+            File = file;
             Progress = progress;
         }
+
+        /// <summary>
+        /// Gets the file currently being uploaded.
+        /// </summary>
+        public IFileEntry File { get; }
 
         /// <summary>
         /// Gets the total progress in the range from 0 to 1.

--- a/Source/Blazorise/EventArguments.cs
+++ b/Source/Blazorise/EventArguments.cs
@@ -286,4 +286,63 @@ namespace Blazorise
         /// </summary>
         public string PanelName { get; }
     }
+
+    /// <summary>
+    /// Supplies the information about the selected files ready to be uploaded.
+    /// </summary>
+    public class FileChangedEventArgs : EventArgs
+    {
+        public FileChangedEventArgs( IFileEntry[] files )
+        {
+            Files = files;
+        }
+
+        /// <summary>
+        /// Gets the list of files ready to be uploaded.
+        /// </summary>
+        public IFileEntry[] Files { get; }
+    }
+
+    /// <summary>
+    /// Supplies the information about the data being written while uploading.
+    /// </summary>
+    public class FileWrittenEventArgs : EventArgs
+    {
+        public FileWrittenEventArgs( long position, byte[] data )
+        {
+            Position = position;
+            Data = data;
+        }
+
+        /// <summary>
+        /// Gets the current position offset based on the original data source.
+        /// </summary>
+        public long Position { get; }
+
+        /// <summary>
+        /// Gets the data buffer.
+        /// </summary>
+        public byte[] Data { get; }
+    }
+
+    /// <summary>
+    /// Provides the progress state of uploaded file.
+    /// </summary>
+    public class FileProgressedEventArgs : EventArgs
+    {
+        public FileProgressedEventArgs( double progress )
+        {
+            Progress = progress;
+        }
+
+        /// <summary>
+        /// Gets the total progress in the range from 0 to 1.
+        /// </summary>
+        public double Progress { get; }
+
+        /// <summary>
+        /// Gets the total progress in the range from 0 to 100.
+        /// </summary>
+        public double Percentage => Progress * 100d;
+    }
 }

--- a/Source/Blazorise/FileEdit.razor
+++ b/Source/Blazorise/FileEdit.razor
@@ -1,7 +1,7 @@
-﻿@inherits BaseInputComponent<string[]>
+﻿@inherits BaseInputComponent<IFileEntry[]>
 @if ( !HasCustomRegistration )
 {
-    <input id="@ElementId" type="file" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" multiple="@Multiple" accept="@Filter" @onchange="@OnChangeHandler" @attributes="@Attributes" />
+    <input @ref="@ElementRef" id="@ElementId" type="file" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" multiple="@Multiple" accept="@Filter" @attributes="@Attributes" />
     @ChildContent
 }
 else

--- a/Source/Blazorise/FileEdit.razor.cs
+++ b/Source/Blazorise/FileEdit.razor.cs
@@ -1,18 +1,34 @@
 ﻿#region Using directives
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 #endregion
 
 namespace Blazorise
 {
-    public partial class FileEdit : BaseInputComponent<string[]>
+    /// <summary>
+    /// This is needed to set the value from javascript because calling generic component directly is not supported by Blazor.
+    /// </summary>
+    public interface IFileEdit
+    {
+        Task NotifyChange( FileEntry[] files );
+    }
+
+    public partial class FileEdit : BaseInputComponent<IFileEntry[]>, IFileEdit
     {
         #region Members
 
         private bool multiple;
+
+        // taken from https://github.com/aspnet/AspNetCore/issues/11159
+        private DotNetObjectReference<FileEditAdapter> dotNetObjectRef;
+
+        private IFileEntry[] files;
 
         #endregion
 
@@ -26,42 +42,98 @@ namespace Blazorise
             base.BuildClasses( builder );
         }
 
-        protected Task OnChangeHandler( ChangeEventArgs e )
+        protected override async Task OnFirstAfterRenderAsync()
         {
-            return CurrentValueHandler( e?.Value?.ToString() );
+            dotNetObjectRef ??= JSRunner.CreateDotNetObjectRef( new FileEditAdapter( this ) );
+
+            await JSRunner.InitializeFileEdit( dotNetObjectRef, ElementRef, ElementId );
+
+            await base.OnFirstAfterRenderAsync();
         }
 
-        protected override Task OnInternalValueChanged( string[] value )
+        protected override void Dispose( bool disposing )
         {
-            return PathChanged.InvokeAsync( value );
+            if ( disposing )
+            {
+                JSRunner.DestroyFileEdit( ElementRef, ElementId );
+                JSRunner.DisposeDotNetObjectRef( dotNetObjectRef );
+            }
+
+            base.Dispose( disposing );
         }
 
-        protected override async Task<ParseValue<string[]>> ParseValueFromStringAsync( string value )
+        public Task NotifyChange( FileEntry[] files )
         {
-            if ( Multiple )
-            {
-                var multipleValues = await JSRunner.GetFilePaths( ElementRef );
+            // Unlike in other Edit components we cannot just call CurrentValueHandler since
+            // we're dealing with complex types instead of a simple string as en element value.
+            //
+            // Because of that we're going to skip CurrentValueHandler and implement all the
+            // update logic here.
 
-                return new ParseValue<string[]>( true, multipleValues, null );
-            }
-            else
+            foreach ( var file in files )
             {
-                return new ParseValue<string[]>( true, new string[] { value?.ToString() }, null );
+                // So that method invocations on the file can be dispatched back here
+                file.Owner = (FileEdit)(object)this;
             }
+
+            InternalValue = files;
+
+            // send the value to the validation for processing
+            ParentValidation?.NotifyInputChanged();
+
+            return Changed.InvokeAsync( new FileChangedEventArgs( files ) );
+        }
+
+        protected override Task OnInternalValueChanged( IFileEntry[] value )
+        {
+            throw new NotImplementedException( $"{nameof( OnInternalValueChanged )} in {nameof( FileEdit )} should never be called." );
+        }
+
+        protected override Task<ParseValue<IFileEntry[]>> ParseValueFromStringAsync( string value )
+        {
+            throw new NotImplementedException( $"{nameof( ParseValueFromStringAsync )} in {nameof( FileEdit )} should never be called." );
+        }
+
+        public Task UpdateWrittenAsync( long position, byte[] data )
+        {
+            return Written.InvokeAsync( new FileWrittenEventArgs( position, data ) );
+        }
+
+        public async Task UpdateProgressAsync( long progressProgress, long progressBuffer, long progressTotal )
+        {
+            ProgressProgress += progressProgress;
+            ProgressBuffer += progressBuffer;
+            ProgressTotal += progressTotal;
+
+            var progress = Math.Round( (double)ProgressProgress / ProgressTotal, 3 );
+
+            if ( Math.Abs( progress - Progress ) > double.Epsilon )
+            {
+                Progress = progress;
+
+                await Progressed.InvokeAsync( new FileProgressedEventArgs( Progress ) );
+            }
+        }
+
+        public async Task WriteToStreamAsync( FileEntry fileEntry, Stream stream )
+        {
+            await new RemoteFileEntryStreamReader( JSRunner, ElementRef, fileEntry, this, MaxMessageSize, MaxBufferSize )
+                .WriteToStreamAsync( stream, CancellationToken.None );
         }
 
         #endregion
 
         #region Properties
 
-        protected override string[] InternalValue
-        {
-            get => null;
-            set
-            {
-                // TODO
-            }
-        }
+        protected override IFileEntry[] InternalValue { get => files; set => files = value; }
+
+        protected long ProgressProgress;
+
+        protected long ProgressBuffer;
+
+        protected long ProgressTotal;
+
+        protected double Progress;
 
         /// <summary>
         /// Enables the multiple file selection.
@@ -85,9 +157,29 @@ namespace Blazorise
         [Parameter] public string Filter { get; set; }
 
         /// <summary>
-        /// Occurs when the file path is changed.
+        /// Gets or sets the max message size when uploading the file.
         /// </summary>
-        [Parameter] public EventCallback<string[]> PathChanged { get; set; }
+        [Parameter] public int MaxMessageSize { get; set; } = 20 * 1024;
+
+        /// <summary>
+        /// Gets or sets the max message size when uploading the file.
+        /// </summary>
+        [Parameter] public int MaxBufferSize { get; set; } = 1024 * 1024;
+
+        /// <summary>
+        /// Occures every time the file(s) has changed.
+        /// </summary>
+        [Parameter] public EventCallback<FileChangedEventArgs> Changed { get; set; }
+
+        /// <summary>
+        /// Occurs every time the part of file has being uploaded.
+        /// </summary>
+        [Parameter] public EventCallback<FileWrittenEventArgs> Written { get; set; }
+
+        /// <summary>
+        /// Notifies the progress of file being uploaded.
+        /// </summary>
+        [Parameter] public EventCallback<FileProgressedEventArgs> Progressed { get; set; }
 
         #endregion
     }

--- a/Source/Blazorise/FileEdit.razor.cs
+++ b/Source/Blazorise/FileEdit.razor.cs
@@ -94,12 +94,12 @@ namespace Blazorise
             throw new NotImplementedException( $"{nameof( ParseValueFromStringAsync )} in {nameof( FileEdit )} should never be called." );
         }
 
-        public Task UpdateWrittenAsync( long position, byte[] data )
+        public Task UpdateWrittenAsync( IFileEntry fileEntry, long position, byte[] data )
         {
-            return Written.InvokeAsync( new FileWrittenEventArgs( position, data ) );
+            return Written.InvokeAsync( new FileWrittenEventArgs( fileEntry, position, data ) );
         }
 
-        public async Task UpdateProgressAsync( long progressProgress, long progressBuffer, long progressTotal )
+        public async Task UpdateProgressAsync( IFileEntry fileEntry, long progressProgress, long progressBuffer, long progressTotal )
         {
             ProgressProgress += progressProgress;
             ProgressBuffer += progressBuffer;
@@ -111,7 +111,7 @@ namespace Blazorise
             {
                 Progress = progress;
 
-                await Progressed.InvokeAsync( new FileProgressedEventArgs( Progress ) );
+                await Progressed.InvokeAsync( new FileProgressedEventArgs( fileEntry, Progress ) );
             }
         }
 
@@ -162,12 +162,12 @@ namespace Blazorise
         [Parameter] public int MaxMessageSize { get; set; } = 20 * 1024;
 
         /// <summary>
-        /// Gets or sets the max message size when uploading the file.
+        /// Gets or sets the max buffer size when uploading the file.
         /// </summary>
         [Parameter] public int MaxBufferSize { get; set; } = 1024 * 1024;
 
         /// <summary>
-        /// Occures every time the file(s) has changed.
+        /// Occurs every time the file(s) has changed.
         /// </summary>
         [Parameter] public EventCallback<FileChangedEventArgs> Changed { get; set; }
 

--- a/Source/Blazorise/FileEdit.razor.cs
+++ b/Source/Blazorise/FileEdit.razor.cs
@@ -167,17 +167,17 @@ namespace Blazorise
         [Parameter] public int MaxBufferSize { get; set; } = 1024 * 1024;
 
         /// <summary>
-        /// Occurs every time the file(s) has changed.
+        /// Occurs every time the selected file(s) has changed.
         /// </summary>
         [Parameter] public EventCallback<FileChangedEventArgs> Changed { get; set; }
 
         /// <summary>
-        /// Occurs every time the part of file has being uploaded.
+        /// Occurs every time the part of file has being writtent to the destination stream.
         /// </summary>
         [Parameter] public EventCallback<FileWrittenEventArgs> Written { get; set; }
 
         /// <summary>
-        /// Notifies the progress of file being uploaded.
+        /// Notifies the progress of file being writtent to the destination stream.
         /// </summary>
         [Parameter] public EventCallback<FileProgressedEventArgs> Progressed { get; set; }
 

--- a/Source/Blazorise/FileEntry.cs
+++ b/Source/Blazorise/FileEntry.cs
@@ -1,0 +1,49 @@
+﻿#region Using directives
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+#endregion
+
+namespace Blazorise
+{
+    public class FileEntry : IFileEntry
+    {
+        #region Members
+
+        private Stream stream;
+
+        #endregion
+
+        #region Methods
+
+        public void Init( FileEdit fileEdit )
+        {
+            Owner = fileEdit;
+        }
+
+        public async Task WriteToStreamAsync( Stream stream )
+        {
+            await Owner.WriteToStreamAsync( this, stream );
+        }
+
+        #endregion
+
+        #region Properties
+
+        internal FileEdit Owner { get; set; }
+
+        public int Id { get; set; }
+
+        public DateTime LastModified { get; set; }
+
+        public string Name { get; set; }
+
+        public long Size { get; set; }
+
+        public string Type { get; set; }
+
+        #endregion
+    }
+}

--- a/Source/Blazorise/FileEntryStreamReader.cs
+++ b/Source/Blazorise/FileEntryStreamReader.cs
@@ -1,0 +1,27 @@
+﻿#region Using directives
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+#endregion
+
+namespace Blazorise
+{
+    public abstract class FileEntryStreamReader
+    {
+        protected readonly IJSRunner jsRunner;
+        protected readonly ElementReference elementRef;
+        protected readonly FileEntry fileEntry;
+        protected readonly FileEdit fileEdit;
+
+        public FileEntryStreamReader( IJSRunner jsRunner, ElementReference elementRef, FileEntry fileEntry, FileEdit fileEdit )
+        {
+            this.jsRunner = jsRunner;
+            this.elementRef = elementRef;
+            this.fileEntry = fileEntry;
+            this.fileEdit = fileEdit;
+        }
+    }
+}

--- a/Source/Blazorise/IFileEntry.cs
+++ b/Source/Blazorise/IFileEntry.cs
@@ -1,0 +1,43 @@
+﻿#region Using directives
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+#endregion
+
+namespace Blazorise
+{
+    /// <summary>
+    /// Defines the upload file.
+    /// </summary>
+    public interface IFileEntry
+    {
+        /// <summary>
+        /// Returns the last modified time of the file.
+        /// </summary>
+        DateTime LastModified { get; }
+
+        /// <summary>
+        /// Returns the name of the file.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Returns the size of the file in bytes
+        /// </summary>
+        long Size { get; }
+
+        /// <summary>
+        /// Returns the MIME type of the file.
+        /// </summary>
+        string Type { get; }
+
+        /// <summary>
+        /// Provides the access to the underline file through the stream.
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <returns></returns>
+        Task WriteToStreamAsync( Stream stream );
+    }
+}

--- a/Source/Blazorise/IJSRunner.cs
+++ b/Source/Blazorise/IJSRunner.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
@@ -41,8 +42,6 @@ namespace Blazorise
 
         ValueTask<bool> ParentHasClass( ElementReference elementRef, string classaname );
 
-        ValueTask<string[]> GetFilePaths( ElementReference element );
-
         ValueTask<bool> ActivateDatePicker( string elementId, string formatSubmit );
 
         ValueTask<TValue[]> GetSelectedOptions<TValue>( string elementId );
@@ -65,5 +64,11 @@ namespace Blazorise
         ValueTask<object> UnregisterClosableComponent( ICloseActivator component );
 
         ValueTask<bool> ScrollIntoView( string anchorTarget );
+
+        ValueTask<bool> InitializeFileEdit( DotNetObjectReference<FileEditAdapter> dotNetObjectRef, ElementReference elementRef, string elementId );
+
+        ValueTask<bool> DestroyFileEdit( ElementReference elementRef, string elementId );
+
+        ValueTask<string> ReadDataAsync( CancellationToken cancellationToken, ElementReference elementRef, int fileEntryId, long startOffset, long count );
     }
 }

--- a/Source/Blazorise/JSRunner.cs
+++ b/Source/Blazorise/JSRunner.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Blazorise.Utils;
 using Microsoft.AspNetCore.Components;
@@ -111,16 +112,6 @@ namespace Blazorise
         }
 
         /// <summary>
-        /// Gets the fake file paths from input field.
-        /// </summary>
-        /// <param name="element">Input field.</param>
-        /// <returns>Returns an array of paths.</returns>
-        public ValueTask<string[]> GetFilePaths( ElementReference element )
-        {
-            return runtime.InvokeAsync<string[]>( $"{BLAZORISE_NAMESPACE}.getFilePaths", element );
-        }
-
-        /// <summary>
         /// Activates the date picker for a given element id.
         /// </summary>
         /// <param name="elementId">Input element id.</param>
@@ -182,6 +173,21 @@ namespace Blazorise
         public ValueTask<bool> ScrollIntoView( string anchorTarget )
         {
             return runtime.InvokeAsync<bool>( $"{BLAZORISE_NAMESPACE}.link.scrollIntoView", anchorTarget );
+        }
+
+        public ValueTask<bool> InitializeFileEdit( DotNetObjectReference<FileEditAdapter> dotNetObjectRef, ElementReference elementRef, string elementId )
+        {
+            return runtime.InvokeAsync<bool>( $"{BLAZORISE_NAMESPACE}.fileEdit.initialize", dotNetObjectRef, elementRef, elementId );
+        }
+
+        public ValueTask<bool> DestroyFileEdit( ElementReference elementRef, string elementId )
+        {
+            return runtime.InvokeAsync<bool>( $"{BLAZORISE_NAMESPACE}.fileEdit.destroy", elementRef, elementId );
+        }
+
+        public ValueTask<string> ReadDataAsync( CancellationToken cancellationToken, ElementReference elementRef, int fileEntryId, long startOffset, long count )
+        {
+            return runtime.InvokeAsync<string>( $"{BLAZORISE_NAMESPACE}.fileEdit.readFileData", cancellationToken, elementRef, fileEntryId, startOffset, count );
         }
     }
 }

--- a/Source/Blazorise/RemoteFileEntryStreamReader.cs
+++ b/Source/Blazorise/RemoteFileEntryStreamReader.cs
@@ -1,0 +1,83 @@
+﻿#region Using directives
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+#endregion
+
+namespace Blazorise
+{
+    internal class RemoteFileEntryStreamReader : FileEntryStreamReader
+    {
+        private readonly int messageSize;
+        private readonly int bufferSize;
+
+        public RemoteFileEntryStreamReader( IJSRunner jsRunner, ElementReference elementRef, FileEntry fileEntry, FileEdit fileEdit, int messageSize, int bufferSize )
+            : base( jsRunner, elementRef, fileEntry, fileEdit )
+        {
+            this.messageSize = messageSize;
+            this.bufferSize = bufferSize;
+        }
+
+        public async Task WriteToStreamAsync( Stream stream, CancellationToken cancellationToken )
+        {
+            await fileEdit.UpdateProgressAsync( 0, 0, fileEntry.Size );
+
+            long position = 0;
+            long queuePosition = 0;
+
+            try
+            {
+                var queue = new Queue<ValueTask<string>>();
+
+                while ( position < fileEntry.Size )
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    while ( queue.Count < bufferSize && queuePosition < fileEntry.Size )
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        var taskPosition = queuePosition;
+                        var taskSize = Math.Min( messageSize, ( fileEntry.Size - queuePosition ) );
+
+                        var task = jsRunner.ReadDataAsync( cancellationToken, elementRef, fileEntry.Id, taskPosition, taskSize );
+
+                        queue.Enqueue( task );
+                        queuePosition += taskSize;
+
+                        await fileEdit.UpdateProgressAsync( 0, taskSize, 0 );
+                    }
+
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    if ( queue.Count == 0 )
+                    {
+                        continue;
+                    }
+
+                    var task2 = queue.Dequeue();
+
+                    var base64 = await task2.ConfigureAwait( true );
+                    var buffer = Convert.FromBase64String( base64 );
+
+                    await stream.WriteAsync( buffer, cancellationToken );
+
+                    position += buffer.Length;
+
+                    // notify of all the changes
+                    await Task.WhenAll(
+                        fileEdit.UpdateWrittenAsync( position, buffer ),
+                        fileEdit.UpdateProgressAsync( buffer.Length, 0, 0 ) );
+                }
+            }
+            finally
+            {
+                await fileEdit.UpdateProgressAsync( -position, -queuePosition, -fileEntry.Size );
+            }
+        }
+    }
+}

--- a/Source/Blazorise/RemoteFileEntryStreamReader.cs
+++ b/Source/Blazorise/RemoteFileEntryStreamReader.cs
@@ -24,7 +24,7 @@ namespace Blazorise
 
         public async Task WriteToStreamAsync( Stream stream, CancellationToken cancellationToken )
         {
-            await fileEdit.UpdateProgressAsync( 0, 0, fileEntry.Size );
+            await fileEdit.UpdateProgressAsync( fileEntry, 0, 0, fileEntry.Size );
 
             long position = 0;
             long queuePosition = 0;
@@ -49,7 +49,7 @@ namespace Blazorise
                         queue.Enqueue( task );
                         queuePosition += taskSize;
 
-                        await fileEdit.UpdateProgressAsync( 0, taskSize, 0 );
+                        await fileEdit.UpdateProgressAsync( fileEntry, 0, taskSize, 0 );
                     }
 
                     cancellationToken.ThrowIfCancellationRequested();
@@ -70,13 +70,13 @@ namespace Blazorise
 
                     // notify of all the changes
                     await Task.WhenAll(
-                        fileEdit.UpdateWrittenAsync( position, buffer ),
-                        fileEdit.UpdateProgressAsync( buffer.Length, 0, 0 ) );
+                        fileEdit.UpdateWrittenAsync( fileEntry, position, buffer ),
+                        fileEdit.UpdateProgressAsync( fileEntry, buffer.Length, 0, 0 ) );
                 }
             }
             finally
             {
-                await fileEdit.UpdateProgressAsync( -position, -queuePosition, -fileEntry.Size );
+                await fileEdit.UpdateProgressAsync( fileEntry, -position, -queuePosition, -fileEntry.Size );
             }
         }
     }

--- a/Source/Blazorise/wwwroot/blazorise.js
+++ b/Source/Blazorise/wwwroot/blazorise.js
@@ -60,20 +60,6 @@ window.blazorise = {
         return true;
     },
 
-    getFilePaths: (element) => {
-        var paths = [];
-
-        if (element) {
-            var files = element.files;
-
-            for (var i = 0; i < files.length; i++) {
-                paths.push(files[i].name);
-            }
-        }
-
-        return paths;
-    },
-
     getSelectedOptions: (elementId) => {
         const element = document.getElementById(elementId);
         const len = element.options.length;
@@ -375,6 +361,78 @@ window.blazorise = {
 
             return true;
         }
+    },
+    fileEdit: {
+        initialize: (adapter, element, elementId) => {
+            var nextFileId = 0;
+
+            element.addEventListener('change', function handleInputFileChange(event) {
+                // Reduce to purely serializable data, plus build an index by ID
+                element._blazorFilesById = {};
+                var fileList = Array.prototype.map.call(element.files, function (file) {
+                    var result = {
+                        id: ++nextFileId,
+                        lastModified: new Date(file.lastModified).toISOString(),
+                        name: file.name,
+                        size: file.size,
+                        type: file.type
+                    };
+                    element._blazorFilesById[result.id] = result;
+
+                    // Attach the blob data itself as a non-enumerable property so it doesn't appear in the JSON
+                    Object.defineProperty(result, 'blob', { value: file });
+
+                    return result;
+                });
+
+                adapter.invokeMethodAsync('NotifyChange', fileList).then(null, function (err) {
+                    throw new Error(err);
+                });
+            });
+
+            return true;
+        },
+        destroy: (element, elementId) => {
+            // TODO:
+            return true;
+        },
+
+        readFileData: function readFileData(element, fileEntryId, startOffset, count) {
+            var readPromise = getArrayBufferFromFileAsync(element, fileEntryId);
+
+            return readPromise.then(function (arrayBuffer) {
+                var uint8Array = new Uint8Array(arrayBuffer, startOffset, count);
+                var base64 = uint8ToBase64(uint8Array);
+                return base64;
+            });
+        },
+
+        ensureArrayBufferReadyForSharedMemoryInterop: function ensureArrayBufferReadyForSharedMemoryInterop(elem, fileId) {
+            return getArrayBufferFromFileAsync(elem, fileId).then(function (arrayBuffer) {
+                getFileById(elem, fileId).arrayBuffer = arrayBuffer;
+            });
+        },
+
+        readFileDataSharedMemory: function readFileDataSharedMemory(readRequest) {
+            // This uses various unsupported internal APIs. Beware that if you also use them,
+            // your code could become broken by any update.
+            var inputFileElementReferenceId = Blazor.platform.readStringField(readRequest, 0);
+            var inputFileElement = document.querySelector('[_bl_' + inputFileElementReferenceId + ']');
+            var fileId = Blazor.platform.readInt32Field(readRequest, 4);
+            var sourceOffset = Blazor.platform.readUint64Field(readRequest, 8);
+            var destination = Blazor.platform.readInt32Field(readRequest, 16);
+            var destinationOffset = Blazor.platform.readInt32Field(readRequest, 20);
+            var maxBytes = Blazor.platform.readInt32Field(readRequest, 24);
+
+            var sourceArrayBuffer = getFileById(inputFileElement, fileId).arrayBuffer;
+            var bytesToRead = Math.min(maxBytes, sourceArrayBuffer.byteLength - sourceOffset);
+            var sourceUint8Array = new Uint8Array(sourceArrayBuffer, sourceOffset, bytesToRead);
+
+            var destinationUint8Array = Blazor.platform.toUint8Array(destination);
+            destinationUint8Array.set(sourceUint8Array, destinationOffset);
+
+            return bytesToRead;
+        }
     }
 };
 
@@ -422,3 +480,94 @@ function showPopper(element, tooltip, arrow, placement) {
     );
     return thePopper;
 }
+
+function getFileById(elem, fileId) {
+    var file = elem._blazorFilesById[fileId];
+    if (!file) {
+        throw new Error('There is no file with ID ' + fileId + '. The file list may have changed');
+    }
+
+    return file;
+}
+
+function getArrayBufferFromFileAsync(elem, fileId) {
+    var file = getFileById(elem, fileId);
+
+    // On the first read, convert the FileReader into a Promise<ArrayBuffer>
+    if (!file.readPromise) {
+        file.readPromise = new Promise(function (resolve, reject) {
+            var reader = new FileReader();
+            reader.onload = function () { resolve(reader.result); };
+            reader.onerror = function (err) { reject(err); };
+            reader.readAsArrayBuffer(file.blob);
+        });
+    }
+
+    return file.readPromise;
+}
+
+var uint8ToBase64 = (function () {
+    // Code from https://github.com/beatgammit/base64-js/
+    // License: MIT
+    var lookup = [];
+
+    var code = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+    for (var i = 0, len = code.length; i < len; ++i) {
+        lookup[i] = code[i];
+    }
+
+    function tripletToBase64(num) {
+        return lookup[num >> 18 & 0x3F] +
+            lookup[num >> 12 & 0x3F] +
+            lookup[num >> 6 & 0x3F] +
+            lookup[num & 0x3F];
+    }
+
+    function encodeChunk(uint8, start, end) {
+        var tmp;
+        var output = [];
+        for (var i = start; i < end; i += 3) {
+            tmp =
+                ((uint8[i] << 16) & 0xFF0000) +
+                ((uint8[i + 1] << 8) & 0xFF00) +
+                (uint8[i + 2] & 0xFF);
+            output.push(tripletToBase64(tmp));
+        }
+        return output.join('');
+    }
+
+    return function fromByteArray(uint8) {
+        var tmp;
+        var len = uint8.length;
+        var extraBytes = len % 3; // if we have 1 byte left, pad 2 bytes
+        var parts = [];
+        var maxChunkLength = 16383; // must be multiple of 3
+
+        // go through the array every three bytes, we'll deal with trailing stuff later
+        for (var i = 0, len2 = len - extraBytes; i < len2; i += maxChunkLength) {
+            parts.push(encodeChunk(
+                uint8, i, (i + maxChunkLength) > len2 ? len2 : (i + maxChunkLength)
+            ));
+        }
+
+        // pad the end with zeros, but make sure to not forget the extra bytes
+        if (extraBytes === 1) {
+            tmp = uint8[len - 1];
+            parts.push(
+                lookup[tmp >> 2] +
+                lookup[(tmp << 4) & 0x3F] +
+                '=='
+            );
+        } else if (extraBytes === 2) {
+            tmp = (uint8[len - 2] << 8) + uint8[len - 1];
+            parts.push(
+                lookup[tmp >> 10] +
+                lookup[(tmp >> 4) & 0x3F] +
+                lookup[(tmp << 2) & 0x3F] +
+                '='
+            );
+        }
+
+        return parts.join('');
+    };
+})();

--- a/Tests/Blazorise.Demo/Pages/Tests/FormsPage.razor
+++ b/Tests/Blazorise.Demo/Pages/Tests/FormsPage.razor
@@ -1,4 +1,6 @@
 ﻿@page "/tests/forms"
+@using System.Diagnostics
+@using System.IO
 @using System.Runtime.Serialization
 <Row>
     <Column>
@@ -99,12 +101,6 @@
                                 <SelectItem Value="4">4</SelectItem>
                             </SelectGroup>
                         </Select>
-                    </FieldBody>
-                </Field>
-                <Field Horizontal="true">
-                    <FieldLabel ColumnSize="ColumnSize.Is2">Default file input</FieldLabel>
-                    <FieldBody ColumnSize="ColumnSize.Is10">
-                        <FileEdit />
                     </FieldBody>
                 </Field>
                 <Field Horizontal="true">
@@ -420,4 +416,45 @@
         Sat,
         Sun,
     }
+
+    //string fileContent;
+
+    //async Task OnFileChanged( FileChangedEventArgs e )
+    //{
+    //    try
+    //    {
+    //        foreach ( var file in e.Files )
+    //        {
+    //            using ( var stream = new MemoryStream() )
+    //            {
+    //                await file.WriteToStreamAsync( stream );
+
+    //                stream.Seek( 0, SeekOrigin.Begin );
+
+    //                using ( var reader = new StreamReader( stream ) )
+    //                {
+    //                    fileContent = await reader.ReadToEndAsync();
+    //                }
+    //            }
+    //        }
+    //    }
+    //    catch ( Exception exc )
+    //    {
+    //        Console.WriteLine( exc.Message );
+    //    }
+    //    finally
+    //    {
+    //        this.StateHasChanged();
+    //    }
+    //}
+
+    //void OnWritten( FileWrittenEventArgs e )
+    //{
+    //    Console.WriteLine( $"Position: {e.Position} Data: {Convert.ToBase64String( e.Data )}" );
+    //}
+
+    //void OnProgressed( FileProgressedEventArgs e )
+    //{
+    //    Console.WriteLine( "Progress: " + e.Percentage );
+    //}
 }

--- a/Tests/Blazorise.Demo/Pages/Tests/FormsPage.razor
+++ b/Tests/Blazorise.Demo/Pages/Tests/FormsPage.razor
@@ -104,6 +104,12 @@
                     </FieldBody>
                 </Field>
                 <Field Horizontal="true">
+                    <FieldLabel ColumnSize="ColumnSize.Is2">Default file input</FieldLabel>
+                    <FieldBody ColumnSize="ColumnSize.Is10">
+                        <FileEdit />
+                    </FieldBody>
+                </Field>
+                <Field Horizontal="true">
                     <FieldLabel ColumnSize="ColumnSize.Is2">Date</FieldLabel>
                     <FieldBody ColumnSize="ColumnSize.Is10">
                         <DateEdit />

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -33,6 +33,8 @@ docs:
         url: /docs/components/numeric/
       - title: "Check"
         url: /docs/components/check/
+      - title: "File"
+        url: /docs/components/file/
       - title: "Field"
         url: /docs/components/field/
       - title: "Addon"

--- a/docs/_docs/components/file.md
+++ b/docs/_docs/components/file.md
@@ -1,0 +1,129 @@
+---
+title: "File component"
+permalink: /docs/components/file/
+excerpt: "Documentation and examples for file component."
+toc: true
+toc_label: "Guide"
+---
+
+Customized, cross-browser consistent, file input control that supports single file and multiple files upload.
+
+## Single file (default)
+
+On single file mode, when file is selected or user does not cancel Browse dialog, `Changed` event will be raised. The return value will be a `FileChangedEventArgs` that will contain only one item in the `Files` property.
+
+```html
+<FileEdit Changed="@OnChanged" />
+```
+
+## Multiple files
+
+Multiple file uploading is supported by enabling `Multiple` attribute to component. In this case `Files` property of `FileChangedEventArgs` can contain multiple files.
+
+```html
+<FileEdit Changed="@OnChanged" Multiple="true" />
+```
+
+## Limiting to certain file types
+
+You can limit the file types by setting the `Filter` attribute to a string containing the allowed file type(s). To specify more than one type, separate the values with a comma.
+
+```html
+<!-- Accept all image formats by IANA media type wildcard-->
+<FileEdit Filter="image/*" />
+
+<!-- Accept specific image formats by IANA type -->
+<FileEdit Filter="image/jpeg, image/png, image/gif" />
+
+<!-- Accept specific image formats by extension -->
+<FileEdit Filter=".jpg, .png, .gif" />
+```
+
+To accept any file type, leave `Filter` as null (default).
+
+**Note:** Not all browsers support or respect the accept attribute on file inputs.
+{: .notice--info}
+
+## Events
+
+### Changed
+
+This is the main event that will be called every time a user selects a single or multiple files. Depending on the mode in which the `FileEdit` currently operates. In all cases the event argument is the same. Only difference is that `Files` array will contain single or multiple items.
+
+### Written
+
+This event will be called on every buffer of data that has being written to the destination stream. It is directly related to the `MaxMessageSize` and `MaxBufferSize` attributes found on `FileEdit` component and will contain the information about currently processed file, it's offset and data array.
+
+### Progressed
+
+Similar to the `Written`, this event will also be called while file is writing to the destination stream but it will contain only the progress and percentage on how much the file is being uploaded.
+
+## Full example
+
+In this example you can see the usage of all events, including the `Written` and `Progressed`. For your own use case you can just focus on `Changed` event.
+
+```cs
+<FileEdit Changed="@OnChanged" Written="@OnWritten" Progressed="@OnProgressed" />
+
+@code{
+    string fileContent;
+
+    async Task OnChanged( FileChangedEventArgs e )
+    {
+        try
+        {
+            foreach ( var file in e.Files )
+            {
+                // A stream is going to be the destination stream we're writing to.                
+                using ( var stream = new MemoryStream() )
+                {
+                    // Here we're telling the FileEdit where to write the upload result
+                    await file.WriteToStreamAsync( stream );
+
+                    // Once we reach this line it means the file is fully uploaded.
+                    // In this case we're going to offset to the beginning of file
+                    // so we can read it.
+                    stream.Seek( 0, SeekOrigin.Begin );
+
+                    // Use the stream reader to read the content of uploaded file,
+                    // in this case we can assume it is a textual file.
+                    using ( var reader = new StreamReader( stream ) )
+                    {
+                        fileContent = await reader.ReadToEndAsync();
+                    }
+                }
+            }
+        }
+        catch ( Exception exc )
+        {
+            Console.WriteLine( exc.Message );
+        }
+        finally
+        {
+            this.StateHasChanged();
+        }
+    }
+
+    void OnWritten( FileWrittenEventArgs e )
+    {
+        Console.WriteLine( $"File: {e.File.Name} Position: {e.Position} Data: {Convert.ToBase64String( e.Data )}" );
+    }
+
+    void OnProgressed( FileProgressedEventArgs e )
+    {
+        Console.WriteLine( $"File: {e.File.Name} Progress: " + e.Percentage );
+    }
+}
+```
+
+## Attributes
+
+| Name                  | Type      | Default     | Description                                                                                  |
+|-----------------------|-----------|-------------|----------------------------------------------------------------------------------------------|
+| Multiple              | boolean   | false       | Specifies that multiple files can be selected.                                               |
+| Filter                | string    | null        | Types of files that the input accepts.                                                       |
+| MaxMessageSize        | int       | 20480       | Max message size (in bytes) when uploading the file.                                         |
+| MaxBufferSize         | int       | 1048576     | Max buffer size (in bytes) when uploading the file.                                          |
+| Changed               | event     |             | Occurs every time the file(s) has changed.                                                   |
+| Written               | event     |             | Occurs every time the part of file has being uploaded.                                       |
+| Progressed            | event     |             | Notifies the progress of file being uploaded.                                                |


### PR DESCRIPTION
#367 

This PR includes the changes to `FileEdit` component to allow the uploading of single or multiple files. It also includes the `Written` and `Progressed` events. Documentation page is also fully written.

All the work is based on the blog post from: https://blog.stevensanderson.com/2019/09/13/blazor-inputfile/