### PR TITLE
file upload optimizations

### DIFF
--- a/Source/Blazorise/EventArguments.cs
+++ b/Source/Blazorise/EventArguments.cs
@@ -298,7 +298,7 @@ namespace Blazorise
         }
 
         /// <summary>
-        /// Gets the list of files ready to be uploaded.
+        /// Gets the list of selected files.
         /// </summary>
         public IFileEntry[] Files { get; }
     }
@@ -356,5 +356,43 @@ namespace Blazorise
         /// Gets the total progress in the range from 0 to 100.
         /// </summary>
         public double Percentage => Progress * 100d;
+    }
+
+    /// <summary>
+    /// Provides the information about the file started to be uploaded.
+    /// </summary>
+    public class FileStartedEventArgs : EventArgs
+    {
+        public FileStartedEventArgs( IFileEntry file )
+        {
+            File = file;
+        }
+
+        /// <summary>
+        /// Gets the file currently being uploaded.
+        /// </summary>
+        public IFileEntry File { get; }
+    }
+
+    /// <summary>
+    /// Provides the information about the file ended uploading.
+    /// </summary>
+    public class FileEndedEventArgs : EventArgs
+    {
+        public FileEndedEventArgs( IFileEntry file, bool success )
+        {
+            File = file;
+            Success = success;
+        }
+
+        /// <summary>
+        /// Gets the file currently being uploaded.
+        /// </summary>
+        public IFileEntry File { get; }
+
+        /// <summary>
+        /// Gets the value indicating if file has finished successfully.
+        /// </summary>
+        public bool Success { get; }
     }
 }

--- a/Source/Blazorise/FileEntry.cs
+++ b/Source/Blazorise/FileEntry.cs
@@ -10,12 +10,6 @@ namespace Blazorise
 {
     public class FileEntry : IFileEntry
     {
-        #region Members
-
-        private Stream stream;
-
-        #endregion
-
         #region Methods
 
         public void Init( FileEdit fileEdit )

--- a/Source/Blazorise/IFileEntry.cs
+++ b/Source/Blazorise/IFileEntry.cs
@@ -24,7 +24,7 @@ namespace Blazorise
         string Name { get; }
 
         /// <summary>
-        /// Returns the size of the file in bytes
+        /// Returns the size of the file in bytes.
         /// </summary>
         long Size { get; }
 
@@ -36,7 +36,7 @@ namespace Blazorise
         /// <summary>
         /// Provides the access to the underline file through the stream.
         /// </summary>
-        /// <param name="stream"></param>
+        /// <param name="stream">Stream to which the upload process if writing.</param>
         /// <returns></returns>
         Task WriteToStreamAsync( Stream stream );
     }

--- a/Source/Blazorise/IJSRunner.cs
+++ b/Source/Blazorise/IJSRunner.cs
@@ -69,6 +69,6 @@ namespace Blazorise
 
         ValueTask<bool> DestroyFileEdit( ElementReference elementRef, string elementId );
 
-        ValueTask<string> ReadDataAsync( CancellationToken cancellationToken, ElementReference elementRef, int fileEntryId, long startOffset, long count );
+        ValueTask<string> ReadDataAsync( CancellationToken cancellationToken, ElementReference elementRef, int fileEntryId, long position, long length );
     }
 }

--- a/Source/Blazorise/JSRunner.cs
+++ b/Source/Blazorise/JSRunner.cs
@@ -185,9 +185,9 @@ namespace Blazorise
             return runtime.InvokeAsync<bool>( $"{BLAZORISE_NAMESPACE}.fileEdit.destroy", elementRef, elementId );
         }
 
-        public ValueTask<string> ReadDataAsync( CancellationToken cancellationToken, ElementReference elementRef, int fileEntryId, long startOffset, long count )
+        public ValueTask<string> ReadDataAsync( CancellationToken cancellationToken, ElementReference elementRef, int fileEntryId, long position, long length )
         {
-            return runtime.InvokeAsync<string>( $"{BLAZORISE_NAMESPACE}.fileEdit.readFileData", cancellationToken, elementRef, fileEntryId, startOffset, count );
+            return runtime.InvokeAsync<string>( $"{BLAZORISE_NAMESPACE}.fileEdit.readFileData", cancellationToken, elementRef, fileEntryId, position, length );
         }
     }
 }

--- a/Source/Blazorise/wwwroot/blazorise.js
+++ b/Source/Blazorise/wwwroot/blazorise.js
@@ -397,11 +397,11 @@ window.blazorise = {
             return true;
         },
 
-        readFileData: function readFileData(element, fileEntryId, startOffset, count) {
+        readFileData: function readFileData(element, fileEntryId, position, length) {
             var readPromise = getArrayBufferFromFileAsync(element, fileEntryId);
 
             return readPromise.then(function (arrayBuffer) {
-                var uint8Array = new Uint8Array(arrayBuffer, startOffset, count);
+                var uint8Array = new Uint8Array(arrayBuffer, position, length);
                 var base64 = uint8ToBase64(uint8Array);
                 return base64;
             });

--- a/Tests/Blazorise.Demo/Pages/Tests/FormsPage.razor
+++ b/Tests/Blazorise.Demo/Pages/Tests/FormsPage.razor
@@ -424,6 +424,7 @@
     }
 
     //string fileContent;
+    //int fileProgress;
 
     //async Task OnFileChanged( FileChangedEventArgs e )
     //{
@@ -435,12 +436,12 @@
     //            {
     //                await file.WriteToStreamAsync( stream );
 
-    //                stream.Seek( 0, SeekOrigin.Begin );
+    //                //stream.Seek( 0, SeekOrigin.Begin );
 
-    //                using ( var reader = new StreamReader( stream ) )
-    //                {
-    //                    fileContent = await reader.ReadToEndAsync();
-    //                }
+    //                //using ( var reader = new StreamReader( stream ) )
+    //                //{
+    //                //    fileContent = await reader.ReadToEndAsync();
+    //                //}
     //            }
     //        }
     //    }
@@ -454,13 +455,25 @@
     //    }
     //}
 
-    //void OnWritten( FileWrittenEventArgs e )
+    //void OnFileStarted( FileStartedEventArgs e )
     //{
-    //    Console.WriteLine( $"Position: {e.Position} Data: {Convert.ToBase64String( e.Data )}" );
+    //    fileProgress = 0;
+    //    Console.WriteLine( $"Started Name: {e.File.Name}" );
     //}
 
-    //void OnProgressed( FileProgressedEventArgs e )
+    //void OnFileEnded( FileEndedEventArgs e )
     //{
-    //    Console.WriteLine( "Progress: " + e.Percentage );
+    //    Console.WriteLine( $"Finished Name: {e.File.Name}, Success: {e.Success}" );
+    //}
+
+    //void OnFileProgressed( FileProgressedEventArgs e )
+    //{
+    //    fileProgress = (int)e.Percentage;
+    //    Console.WriteLine( $"Name: {e.File.Name} Progress: {e.Percentage}" );
+    //}
+
+    //void OnFileWritten( FileWrittenEventArgs e )
+    //{
+    //    Console.WriteLine( $"Name: {e.File.Name} Position: {e.Position} Data: {Convert.ToBase64String( e.Data )}" );
     //}
 }

--- a/docs/_docs/components/file.md
+++ b/docs/_docs/components/file.md
@@ -52,11 +52,19 @@ This is the main event that will be called every time a user selects a single or
 
 ### Written
 
-This event will be called on every buffer of data that has being written to the destination stream. It is directly related to the `MaxMessageSize` and `MaxBufferSize` attributes found on `FileEdit` component and will contain the information about currently processed file, it's offset and data array.
+This event will be called on every buffer of data that has being written to the destination stream. It is directly related to the `MaxMessageSize` attribute found on `FileEdit` component and will contain the information about currently processed file, it's offset and data array.
 
 ### Progressed
 
 Similar to the `Written`, this event will also be called while file is writing to the destination stream but it will contain only the progress and percentage on how much the file is being uploaded.
+
+### Started
+
+This event will be called each time one of the selected file(s) has started the upload process.
+
+### Ended
+
+This event is fired after the file has ended the upload process. If there was no error it will have `Success` property set to true.
 
 ## Full example
 
@@ -111,7 +119,7 @@ In this example you can see the usage of all events, including the `Written` and
 
     void OnProgressed( FileProgressedEventArgs e )
     {
-        Console.WriteLine( $"File: {e.File.Name} Progress: " + e.Percentage );
+        Console.WriteLine( $"File: {e.File.Name} Progress: {e.Percentage}" );
     }
 }
 ```
@@ -123,7 +131,8 @@ In this example you can see the usage of all events, including the `Written` and
 | Multiple              | boolean   | false       | Specifies that multiple files can be selected.                                               |
 | Filter                | string    | null        | Types of files that the input accepts.                                                       |
 | MaxMessageSize        | int       | 20480       | Max message size (in bytes) when uploading the file.                                         |
-| MaxBufferSize         | int       | 1048576     | Max buffer size (in bytes) when uploading the file.                                          |
 | Changed               | event     |             | Occurs every time the file(s) has changed.                                                   |
 | Written               | event     |             | Occurs every time the part of file has being uploaded.                                       |
 | Progressed            | event     |             | Notifies the progress of file being uploaded.                                                |
+| Started               | event     |             | Occurs when an individual file upload has started.                                           |
+| Ended                 | event     |             | Occurs when an individual file upload has ended.                                             |


### PR DESCRIPTION
#367 

Made some changes to the FileEdit upload process

- removed `tasked`  batches when read-writing the streams
- added new events `Started` and `Ended`

@iberisoft Can you test this PR before I merge? I cannot find any issue with the upload files sizes. The only issue I experience is slow upload on WebAssembly. On server-side project it works really fast.