### PR TITLE
Add DisplayGridColumns parameter

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -8,7 +8,7 @@
             @if ( ShowCaptions )
             {
                 <TableRow>
-                    @foreach ( var column in GridDisplayColumns )
+                    @foreach ( var column in VisibleColumns )
                     {
                         @if ( column.ColumnType == DataGridColumnType.Command )
                         {
@@ -41,7 +41,7 @@
             @if ( Filterable )
             {
                 <TableRow>
-                    @foreach ( var column in GridDisplayColumns )
+                    @foreach ( var column in VisibleColumns )
                     {
                         @if ( !column.Filterable )
                             continue;
@@ -79,7 +79,7 @@
                 }
                 else
                 {
-                    <_DataGridRow @key="@item" TItem="TItem" Item="@item" Columns="@GridDisplayColumns" HoverCursor="@(RowHoverCursor?.Invoke(item) ?? Cursor.Pointer)" Edit="@OnEditCommand" Delete="@OnDeleteCommand" Save="@OnSaveCommand" Cancel="@OnCancelCommand" Selected="@OnSelectedCommand" />
+                    <_DataGridRow @key="@item" TItem="TItem" Item="@item" Columns="@VisibleColumns" HoverCursor="@(RowHoverCursor?.Invoke(item) ?? Cursor.Pointer)" Edit="@OnEditCommand" Delete="@OnDeleteCommand" Save="@OnSaveCommand" Cancel="@OnCancelCommand" Selected="@OnSelectedCommand" />
                     @if ( DetailRowTemplate != null )
                     {
                         var canShow = DetailRowTrigger?.Invoke( item ) ?? true;

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -8,7 +8,7 @@
             @if ( ShowCaptions )
             {
                 <TableRow>
-                    @foreach ( var column in Columns )
+                    @foreach ( var column in GridDisplayColumns )
                     {
                         @if ( column.ColumnType == DataGridColumnType.Command )
                         {
@@ -41,7 +41,7 @@
             @if ( Filterable )
             {
                 <TableRow>
-                    @foreach ( var column in Columns )
+                    @foreach ( var column in GridDisplayColumns )
                     {
                         @if ( !column.Filterable )
                             continue;
@@ -79,7 +79,7 @@
                 }
                 else
                 {
-                    <_DataGridRow @key="@item" TItem="TItem" Item="@item" Columns="@Columns" HoverCursor="@(RowHoverCursor?.Invoke(item) ?? Cursor.Pointer)" Edit="@OnEditCommand" Delete="@OnDeleteCommand" Save="@OnSaveCommand" Cancel="@OnCancelCommand" Selected="@OnSelectedCommand" />
+                    <_DataGridRow @key="@item" TItem="TItem" Item="@item" Columns="@GridDisplayColumns" HoverCursor="@(RowHoverCursor?.Invoke(item) ?? Cursor.Pointer)" Edit="@OnEditCommand" Delete="@OnDeleteCommand" Save="@OnSaveCommand" Cancel="@OnCancelCommand" Selected="@OnSelectedCommand" />
                     @if ( DetailRowTemplate != null )
                     {
                         var canShow = DetailRowTrigger?.Invoke( item ) ?? true;

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -465,6 +465,11 @@ namespace Blazorise.DataGrid
         protected IEnumerable<BaseDataGridColumn<TItem>> EditableColumns => Columns.Where( x => x.ColumnType != DataGridColumnType.Command && x.Editable );
 
         /// <summary>
+        /// Gets only columns that are available for display in the grid.
+        /// </summary>
+        protected IEnumerable<BaseDataGridColumn<TItem>> GridDisplayColumns => Columns.Where( x => x.ColumnType == DataGridColumnType.Command || x.DisplayInGrid );
+
+        /// <summary>
         /// Returns true if <see cref="Data"/> is safe to modify.
         /// </summary>
         protected bool CanInsertNewItem => Editable && Data is ICollection<TItem>;

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -465,9 +465,9 @@ namespace Blazorise.DataGrid
         protected IEnumerable<BaseDataGridColumn<TItem>> EditableColumns => Columns.Where( x => x.ColumnType != DataGridColumnType.Command && x.Editable );
 
         /// <summary>
-        /// Gets only columns that are available for display in the grid.
+        /// Gets only columns that are visible in the grid.
         /// </summary>
-        protected IEnumerable<BaseDataGridColumn<TItem>> GridDisplayColumns => Columns.Where( x => x.ColumnType == DataGridColumnType.Command || x.DisplayInGrid );
+        protected IEnumerable<BaseDataGridColumn<TItem>> VisibleColumns => Columns.Where( x => x.ColumnType == DataGridColumnType.Command || x.VisibleInGrid );
 
         /// <summary>
         /// Returns true if <see cref="Data"/> is safe to modify.

--- a/Source/Extensions/Blazorise.DataGrid/DataGridColumn.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGridColumn.razor.cs
@@ -142,9 +142,9 @@ namespace Blazorise.DataGrid
         [Parameter] public bool Filterable { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets whether the column is visible in the grid
+        /// Gets or sets whether the column is visible in the grid.
         /// </summary>
-        [Parameter] public bool DisplayInGrid { get; set; } = true;
+        [Parameter] public bool VisibleInGrid { get; set; } = true;
 
         /// <summary>
         /// The width of the column.

--- a/Source/Extensions/Blazorise.DataGrid/DataGridColumn.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGridColumn.razor.cs
@@ -142,6 +142,11 @@ namespace Blazorise.DataGrid
         [Parameter] public bool Filterable { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets whether the column is visible in the grid
+        /// </summary>
+        [Parameter] public bool DisplayInGrid { get; set; } = true;
+
+        /// <summary>
         /// The width of the column.
         /// </summary>
         [Parameter] public string Width { get; set; }


### PR DESCRIPTION
Add DisplayGridColumns parameter so that columns can be hidden on the grid but still available in the editor.

The datagrid now takes its list of columns from GridDisplayColumns which filters any columns with DisplayGridColumns=false.