### PR TITLE
Update Autocomplete.razor.cs

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,3 +211,18 @@ public class Startup
     }
 }
 ```
+
+## Try Preview
+
+If you're willing to try preview versions of Blazorise all you need to do is to setup Visual Studio so it knows how to use Blazorise [MyGet feed](https://www.myget.org/feed/Details/blazorise). The easies way to do this is to create `NuGet.config` file and place it into your solution root folder. Then you copy the following content and paste it to the `NuGet.config`.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="BlazoriseMyGet" value="https://www.myget.org/F/blazorise/api/v3/index.json" />
+  </packageSources>
+</configuration>
+```
+
+Now you will be able to get preview versions of Blazorise with the latest changes and bug fixes.

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -62,7 +62,7 @@ namespace Blazorise.Components
 
             var activeItemIndex = ActiveItemIndex;
 
-            if ( ( e.Code == "Enter" || e.Code == "NumpadEnter" ) )
+            if ( ( e.Code == "Enter" || e.Code == "NumpadEnter" || e.Code == "Tab" ) )
             {
                 var item = FilteredData.ElementAtOrDefault( activeItemIndex );
 


### PR DESCRIPTION
I think could be usefull to handle the Tab key as a selection on the AutoComplete control. If you use only Enter and you are inside a form you will launch a submit.