### PR TITLE
refactor: removed ColumnSize from input components

### DIFF
--- a/Source/Blazorise.AntDesign/FieldBody.razor.cs
+++ b/Source/Blazorise.AntDesign/FieldBody.razor.cs
@@ -49,7 +49,7 @@ namespace Blazorise.AntDesign
 
         #region Properties
 
-        protected override bool UseColumnSizes => false; // disable column-size on the body, as we're going to add it on container
+        protected override bool ColumnSizeSupported => false; // disable column-size on the body, as we're going to add it on container
 
         protected string ContainerClassNames => containerClassBuilder.Class;
 

--- a/Source/Blazorise.AntDesign/FieldLabel.razor.cs
+++ b/Source/Blazorise.AntDesign/FieldLabel.razor.cs
@@ -49,7 +49,7 @@ namespace Blazorise.AntDesign
 
         #region Properties
 
-        protected override bool UseColumnSizes => false; // disable column-size on the label, as we're going to add it on container
+        protected override bool ColumnSizeSupported => false; // disable column-size on the label, as we're going to add it on container
 
         protected string ContainerClassNames => containerClassBuilder.Class;
 

--- a/Source/Blazorise.Bootstrap/FieldBody.razor
+++ b/Source/Blazorise.Bootstrap/FieldBody.razor
@@ -1,6 +1,6 @@
 ﻿@inherits Blazorise.FieldBody
 <CascadingValue Value=this>
-    @if ( ParentIsHorizontal )
+    @if ( IsHorizontal )
     {
         <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
             @ChildContent

--- a/Source/Blazorise.Bulma/FieldBody.razor
+++ b/Source/Blazorise.Bulma/FieldBody.razor
@@ -1,6 +1,6 @@
 ﻿@inherits Blazorise.FieldBody
 <CascadingValue Value=this>
-    @if ( ParentIsHorizontal )
+    @if ( IsHorizontal )
     {
         <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
             @ChildContent

--- a/Source/Blazorise.Bulma/FieldBody.razor.cs
+++ b/Source/Blazorise.Bulma/FieldBody.razor.cs
@@ -20,7 +20,7 @@ namespace Blazorise.Bulma
 
         #region Properties
 
-        protected override bool UseColumnSizes => false; // Bulma does not support column sizes on fields.
+        protected override bool ColumnSizeSupported => false; // Bulma does not support column sizes on fields.
 
         #endregion
     }

--- a/Source/Blazorise.Bulma/FieldLabel.razor.cs
+++ b/Source/Blazorise.Bulma/FieldLabel.razor.cs
@@ -20,7 +20,7 @@ namespace Blazorise.Bulma
 
         #region Properties
 
-        protected override bool UseColumnSizes => false; // Bulma does not support column sizes on fields.
+        protected override bool ColumnSizeSupported => false; // Bulma does not support column sizes on fields.
 
         #endregion
     }

--- a/Source/Blazorise/BaseInputComponent.razor.cs
+++ b/Source/Blazorise/BaseInputComponent.razor.cs
@@ -11,7 +11,7 @@ namespace Blazorise
     /// <summary>
     /// Base component for all the input component types.
     /// </summary>
-    public abstract class BaseInputComponent<TValue> : BaseSizableComponent, IValidationInput
+    public abstract class BaseInputComponent<TValue> : BaseComponent, IValidationInput
     {
         #region Members
 
@@ -117,6 +117,8 @@ namespace Blazorise
         /// <inheritdoc/>
         public virtual object ValidationValue => InternalValue;
 
+        protected bool ParentIsFieldBody => ParentFieldBody != null;
+
         /// <summary>
         /// Gets or sets the internal edit value.
         /// </summary>
@@ -207,6 +209,8 @@ namespace Blazorise
         /// Parent validation container.
         /// </summary>
         [CascadingParameter] protected Validation ParentValidation { get; set; }
+
+        [CascadingParameter] protected FieldBody ParentFieldBody { get; set; }
 
         #endregion
     }

--- a/Source/Blazorise/BaseSizableFieldComponent.cs
+++ b/Source/Blazorise/BaseSizableFieldComponent.cs
@@ -11,11 +11,7 @@ namespace Blazorise
     /// <summary>
     /// Base class for field and input components that can be sized in grid layout.
     /// </summary>
-    /// <remarks>
-    /// TODO: Currently this class is inherited by the input components. This is problematic because the sizing of
-    /// input components is done by the FieldBody. See if there is a need for this class to be used by the input components!!
-    /// </remarks>
-    public abstract class BaseSizableComponent : BaseComponent
+    public abstract class BaseSizableFieldComponent : BaseComponent
     {
         #region Members
 
@@ -27,7 +23,7 @@ namespace Blazorise
 
         protected override void BuildClasses( ClassBuilder builder )
         {
-            if ( ColumnSize != null && UseColumnSizes )
+            if ( ColumnSize != null && ColumnSizeSupported )
                 builder.Append( ColumnSize.Class( ClassProvider ) );
 
             base.BuildClasses( builder );
@@ -45,17 +41,24 @@ namespace Blazorise
 
         #region Properties
 
-        protected virtual bool ParentIsHorizontal => ParentField?.Horizontal == true;
+        /// <summary>
+        /// True if component is inside of a <see cref="Field"/> marked as horizontal.
+        /// </summary>
+        protected virtual bool IsHorizontal => ParentField?.Horizontal == true;
 
-        protected virtual bool ParentIsField => ParentField != null;
-
-        protected virtual bool ParentIsFieldBody => ParentFieldBody != null;
+        /// <summary>
+        /// True if component is inside of a <see cref="Field"/>.
+        /// </summary>
+        protected virtual bool IsInsideField => ParentField != null;
 
         /// <summary>
         /// Used to override the use of column sizes by some of the providers.
         /// </summary>
-        protected virtual bool UseColumnSizes => true;
+        protected virtual bool ColumnSizeSupported => true;
 
+        /// <summary>
+        /// Defines the column size inside of a <see cref="Field"/> component.
+        /// </summary>
         [Parameter]
         public IFluentColumn ColumnSize
         {
@@ -69,10 +72,6 @@ namespace Blazorise
         }
 
         [CascadingParameter] protected Field ParentField { get; set; }
-
-        [CascadingParameter] protected FieldBody ParentFieldBody { get; set; }
-
-        [CascadingParameter] protected Tooltip ParentTooltip { get; set; }
 
         #endregion
     }

--- a/Source/Blazorise/Button.razor
+++ b/Source/Blazorise/Button.razor
@@ -1,4 +1,4 @@
-﻿@inherits BaseSizableComponent
+﻿@inherits BaseComponent
 @if ( !HasCustomRegistration )
 {
     <button @ref="@ElementRef" id="@ElementId" type="@Type.ToButtonTypeString()" class="@ClassNames" style="@StyleNames" disabled="@Disabled" aria-pressed="@Active" @onclick="@ClickHandler" @attributes="@Attributes">

--- a/Source/Blazorise/Button.razor.cs
+++ b/Source/Blazorise/Button.razor.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazorise
 {
-    public partial class Button : BaseSizableComponent
+    public partial class Button : BaseComponent
     {
         #region Members
 
@@ -100,7 +100,15 @@ namespace Blazorise
 
         #region Properties
 
+        /// <summary>
+        /// True if button is part of an addons or dropdown group.
+        /// </summary>
         protected bool IsAddons => ParentButtons?.Role == ButtonsRole.Addons || ParentDropdown?.IsGroup == true;
+
+        /// <summary>
+        /// True if button is placed inside of a <see cref="Field"/>.
+        /// </summary>
+        protected bool ParentIsField => ParentField != null;
 
         /// <summary>
         /// Occurs when the button is clicked.
@@ -227,6 +235,8 @@ namespace Blazorise
         [CascadingParameter] protected Buttons ParentButtons { get; set; }
 
         [CascadingParameter] protected Addons ParentAddons { get; set; }
+
+        [CascadingParameter] protected Field ParentField { get; set; }
 
         /// <summary>
         /// Gets or sets the command to be executed when clicked on a button.

--- a/Source/Blazorise/FieldBody.razor
+++ b/Source/Blazorise/FieldBody.razor
@@ -1,4 +1,4 @@
-﻿@inherits BaseSizableComponent
+﻿@inherits BaseSizableFieldComponent
 @if ( !HasCustomRegistration )
 {
     <CascadingValue Value=this>

--- a/Source/Blazorise/FieldBody.razor.cs
+++ b/Source/Blazorise/FieldBody.razor.cs
@@ -8,7 +8,10 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazorise
 {
-    public partial class FieldBody : BaseSizableComponent
+    /// <summary>
+    /// Container for input components when <see cref="Field"/> has <see cref="Field.Horizontal"/> set to true.
+    /// </summary>
+    public partial class FieldBody : BaseSizableFieldComponent
     {
         #region Members
 

--- a/Source/Blazorise/FieldLabel.razor
+++ b/Source/Blazorise/FieldLabel.razor
@@ -1,4 +1,4 @@
-﻿@inherits BaseSizableComponent
+﻿@inherits BaseSizableFieldComponent
 @if ( !HasCustomRegistration )
 {
     <label class="@ClassNames" style="@StyleNames" for="@For" @attributes="@Attributes">

--- a/Source/Blazorise/FieldLabel.razor.cs
+++ b/Source/Blazorise/FieldLabel.razor.cs
@@ -9,9 +9,9 @@ using Microsoft.AspNetCore.Components;
 namespace Blazorise
 {
     /// <summary>
-    /// Sets the field label.
+    /// Label for a <see cref="Field"/> component.
     /// </summary>
-    public partial class FieldLabel : BaseSizableComponent
+    public partial class FieldLabel : BaseSizableFieldComponent
     {
         #region Members
 
@@ -24,7 +24,7 @@ namespace Blazorise
         protected override void BuildClasses( ClassBuilder builder )
         {
             builder.Append( ClassProvider.FieldLabel() );
-            builder.Append( ClassProvider.FieldLabelHorizontal(), ParentIsHorizontal );
+            builder.Append( ClassProvider.FieldLabelHorizontal(), IsHorizontal );
             builder.Append( ClassProvider.ToScreenreader( Screenreader ), Screenreader != Screenreader.Always );
 
             base.BuildClasses( builder );
@@ -34,6 +34,9 @@ namespace Blazorise
 
         #region Properties
 
+        /// <summary>
+        /// Gets or sets the ID of an element that this label belongs to.
+        /// </summary>
         [Parameter] public string For { get; set; }
 
         /// <summary>


### PR DESCRIPTION
#303 Remove the need for FieldBody for horizontal fields

**Copied from task:** After further investigation I found FieldBody has more benefits to stay. Instead I will refactor and remove BaseSizableComponent inheritance from all input components. The problem with defining column sizes on inputs directly is that it's generally not supported by all providers. Defining column sizes on button or check makes little sense. That should go to it's container. And it is precisely why FieldBody is used for.

Changed in this PR:

- removed inheritance if BaseSizableComponent from all input components
- replaced BaseSizableComponent with BaseSizableFieldComponent
- removed unused cascade parameters
- renamed some of the properties