### PR TITLE
Fix slider initial value ignoring max

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Tests/FormsPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/FormsPage.razor
@@ -133,6 +133,7 @@
                     <FieldLabel ColumnSize="ColumnSize.Is2">Range slider</FieldLabel>
                     <FieldBody ColumnSize="ColumnSize.Is10">
                         <Slider TValue="decimal" Value="25m" Max="100m" />
+                        <Slider TValue="int" Min="10" Max="1000" Value="800" Step="5" />
                     </FieldBody>
                 </Field>
                 <Field Horizontal="true">

--- a/Source/Blazorise/Slider.razor
+++ b/Source/Blazorise/Slider.razor
@@ -2,7 +2,7 @@
 @inherits Blazorise.BaseInputComponent<TValue>
 @if ( !HasCustomRegistration )
 {
-    <input type="range" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" step="@Step" value="@CurrentValueAsString" min="@Min" max="@Max" @onchange="@OnChangeHandler" @attributes="@Attributes">
+    <input type="range" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" step="@Step" min="@Min" max="@Max" value="@CurrentValueAsString" @onchange="@OnChangeHandler" @attributes="@Attributes">
     @ChildContent
     @Feedback
 }


### PR DESCRIPTION
- Simple fix for `Slider` initial value ignoring `Max` on Bootstrap provider
- Add demo/test for `Slider` having large `Max`

Fixes #677 