### PR TITLE
feat: Add option to control column visibility in display mode

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -8,7 +8,7 @@
             @if ( ShowCaptions )
             {
                 <TableRow Class="@HeaderRowClass" Style="@HeaderRowStyle">
-                    @foreach ( var column in Columns )
+                    @foreach ( var column in DisplayableColumns )
                     {
                         @if ( column.ColumnType == DataGridColumnType.Command )
                         {
@@ -41,7 +41,7 @@
             @if ( Filterable )
             {
                 <TableRow Class="@FilterRowClass" Style="@FilterRowStyle">
-                    @foreach ( var column in Columns )
+                    @foreach ( var column in DisplayableColumns )
                     {
                         @if ( !column.Filterable )
                             continue;
@@ -86,7 +86,7 @@
                 }
                 else
                 {
-                    <_DataGridRow @key="@item" TItem="TItem" Item="@item" Columns="@Columns" HoverCursor="@(RowHoverCursor?.Invoke(item) ?? Cursor.Pointer)" Edit="@OnEditCommand" Delete="@OnDeleteCommand" Save="@OnSaveCommand" Cancel="@OnCancelCommand" Selected="@OnSelectedCommand" Clicked="@OnRowClickedCommand" DoubleClicked="@OnRowDoubleClickedCommand" Class="@RowClass?.Invoke(item)" Style="@RowStyle?.Invoke(item)" />
+                    <_DataGridRow @key="@item" TItem="TItem" Item="@item" Columns="@DisplayableColumns" HoverCursor="@(RowHoverCursor?.Invoke(item) ?? Cursor.Pointer)" Edit="@OnEditCommand" Delete="@OnDeleteCommand" Save="@OnSaveCommand" Cancel="@OnCancelCommand" Selected="@OnSelectedCommand" Clicked="@OnRowClickedCommand" DoubleClicked="@OnRowDoubleClickedCommand" Class="@RowClass?.Invoke(item)" Style="@RowStyle?.Invoke(item)" />
                     @if ( DetailRowTemplate != null )
                     {
                         var canShow = DetailRowTrigger?.Invoke( item ) ?? true;
@@ -104,7 +104,7 @@
         @if ( HasAggregates )
         {
             <TableFooter>
-                <_DataGridAggregateRow TItem="TItem" Aggregates="@Aggregates" Columns="@Columns" Class="@GroupRowClass" Style="@GroupRowStyle" />
+                <_DataGridAggregateRow TItem="TItem" Aggregates="@Aggregates" Columns="@DisplayableColumns" Class="@GroupRowClass" Style="@GroupRowStyle" />
             </TableFooter>
         }
     </Table>

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -511,6 +511,11 @@ namespace Blazorise.DataGrid
         protected IEnumerable<DataGridColumn<TItem>> EditableColumns => Columns.Where( x => x.ColumnType != DataGridColumnType.Command && x.Editable );
 
         /// <summary>
+        /// Gets only columns that are available for display in the grid.
+        /// </summary>
+        protected IEnumerable<DataGridColumn<TItem>> DisplayableColumns => Columns.Where( x => x.ColumnType == DataGridColumnType.Command || x.Displayable );
+
+        /// <summary>
         /// Returns true if <see cref="Data"/> is safe to modify.
         /// </summary>
         protected bool CanInsertNewItem => Editable && Data is ICollection<TItem>;

--- a/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
@@ -163,6 +163,11 @@ namespace Blazorise.DataGrid
         [Parameter] public bool Editable { get; set; }
 
         /// <summary>
+        /// Gets or sets whether column can be displayed on a grid.
+        /// </summary>
+        [Parameter] public bool Displayable { get; set; } = true;
+
+        /// <summary>
         /// Allows the cell values to be entered while the grid is in the new-item state.
         /// </summary>
         [Parameter] public bool CellsEditableOnNewCommand { get; set; } = true;


### PR DESCRIPTION
#605 Set DataColumn visibility to true/false but still allow popup/form to show field for editing

Added new property `Displayable` to data-grid column. It is used to show or hide column when grid is in display mode.

This PR is the implemented based on #615