### PR TITLE
fix: ValidatedAll not called for Auto validations

### DIFF
--- a/Source/Blazorise/EventHandlers.cs
+++ b/Source/Blazorise/EventHandlers.cs
@@ -18,8 +18,6 @@ namespace Blazorise
 
     public delegate void ValidatingAllEventHandler( ValidatingAllEventArgs e );
 
-    public delegate void ValidatedAllEventHandler();
-
     public delegate void ValidatedEventHandler( ValidatedEventArgs e );
 
     public delegate void ClearAllValidatinaEventHandler();

--- a/Source/Blazorise/IValidation.cs
+++ b/Source/Blazorise/IValidation.cs
@@ -1,0 +1,19 @@
+﻿#region Using directives
+using System;
+using System.Collections.Generic;
+using System.Text;
+#endregion
+
+namespace Blazorise
+{
+    /// <summary>
+    /// Base interface for validation component.
+    /// </summary>
+    public interface IValidation
+    {
+        /// <summary>
+        /// Gets the last validation status.
+        /// </summary>
+        ValidationStatus Status { get; }
+    }
+}

--- a/Source/Blazorise/Validation.razor.cs
+++ b/Source/Blazorise/Validation.razor.cs
@@ -15,7 +15,10 @@ using Microsoft.AspNetCore.Components.Forms;
 
 namespace Blazorise
 {
-    public partial class Validation : ComponentBase
+    /// <summary>
+    /// Container for input component that can check for different kind of validations.
+    /// </summary>
+    public partial class Validation : ComponentBase, IValidation
     {
         #region Members
 
@@ -64,6 +67,8 @@ namespace Blazorise
             {
                 ParentValidations.ValidatingAll += OnValidatingAll;
                 ParentValidations.ClearingAll += OnClearingAll;
+
+                ParentValidations.NotifyValidationInitialized( this );
             }
 
             base.OnInitialized();
@@ -164,7 +169,7 @@ namespace Blazorise
                 {
                     Status = matchStatus;
 
-                    ValidationStatusChanged?.Invoke( this, new ValidationStatusChangedEventArgs( Status ) );
+                    NotifyValidationStatusChanged( Status );
                 }
             }
             else if ( EditContext != null && hasFieldIdentifier )
@@ -178,7 +183,7 @@ namespace Blazorise
                 Status = messages[fieldIdentifier].Any() ? ValidationStatus.Error : ValidationStatus.Success;
                 LastErrorMessage = Status == ValidationStatus.Error ? string.Join( "; ", messages[fieldIdentifier] ) : null;
 
-                ValidationStatusChanged?.Invoke( this, new ValidationStatusChangedEventArgs( Status, LastErrorMessage ) );
+                NotifyValidationStatusChanged( Status, LastErrorMessage );
             }
             else
             {
@@ -197,7 +202,7 @@ namespace Blazorise
                         Status = validatorEventArgs.Status;
                         LastErrorMessage = Status == ValidationStatus.Error ? validatorEventArgs.ErrorText : null;
 
-                        ValidationStatusChanged?.Invoke( this, new ValidationStatusChangedEventArgs( Status, LastErrorMessage ) );
+                        NotifyValidationStatusChanged( Status, LastErrorMessage );
                     }
                 }
             }
@@ -211,7 +216,14 @@ namespace Blazorise
         public void Clear()
         {
             Status = ValidationStatus.None;
-            ValidationStatusChanged?.Invoke( this, new ValidationStatusChangedEventArgs( Status ) );
+            NotifyValidationStatusChanged( Status );
+        }
+
+        private void NotifyValidationStatusChanged( ValidationStatus status, string message = null )
+        {
+            ValidationStatusChanged?.Invoke( this, new ValidationStatusChangedEventArgs( status, message ) );
+
+            ParentValidations?.NotifyValidationStatusChanged();
         }
 
         #endregion

--- a/Source/Blazorise/Validations.razor.cs
+++ b/Source/Blazorise/Validations.razor.cs
@@ -10,6 +10,9 @@ using Microsoft.AspNetCore.Components.Forms;
 
 namespace Blazorise
 {
+    /// <summary>
+    /// Container for multiple validations.
+    /// </summary>
     public partial class Validations : ComponentBase
     {
         #region Members
@@ -19,9 +22,12 @@ namespace Blazorise
         /// </summary>
         public event ValidatingAllEventHandler ValidatingAll;
 
-        public event ValidatedAllEventHandler ValidatedAll;
-
         public event ClearAllValidatinaEventHandler ClearingAll;
+
+        /// <summary>
+        /// List of validations placed inside of this container.
+        /// </summary>
+        private List<IValidation> validations = new List<IValidation>();
 
         #endregion
 
@@ -46,7 +52,7 @@ namespace Blazorise
 
             if ( result )
             {
-                ValidatedAll?.Invoke();
+                ValidatedAll.InvokeAsync( null );
             }
 
             return result;
@@ -84,9 +90,28 @@ namespace Blazorise
             return validated;
         }
 
+        internal void NotifyValidationInitialized( IValidation validation )
+        {
+            if ( !validations.Contains( validation ) )
+            {
+                validations.Add( validation );
+            }
+        }
+
+        internal void NotifyValidationStatusChanged()
+        {
+            if ( Mode == ValidationMode.Manual )
+                return;
+
+            if ( validations.All( x => x.Status == ValidationStatus.Success ) )
+            {
+                ValidatedAll.InvokeAsync( null );
+            }
+        }
+
         #endregion
 
-        #region Properties        
+        #region Properties
 
         protected EditContext EditContext { get; set; }
 
@@ -99,6 +124,8 @@ namespace Blazorise
         /// Specifies the top-level model object for the form. An edit context will be constructed for this model.
         /// </summary>
         [Parameter] public object Model { get; set; }
+
+        [Parameter] public EventCallback ValidatedAll { get; set; }
 
         [Parameter] public RenderFragment ChildContent { get; set; }
 


### PR DESCRIPTION
#583 ValidatedAll not called when ValidationMode.Auto

- `ValidatedAll` will now be called every time that all validations have passed
- Converted `ValidatedAll` to EventCallback
- Removed `ValidatedAllEventHandler` delegate