### PR TITLE
[AntDesign] fix: ant card image/cover

### DIFF
--- a/Source/Blazorise.AntDesign/AntDesignThemeGenerator.cs
+++ b/Source/Blazorise.AntDesign/AntDesignThemeGenerator.cs
@@ -443,6 +443,16 @@ namespace Blazorise.AntDesign
                 .Append( $"border-radius: {GetBorderRadius( theme, options?.BorderRadius, Var( ThemeVariables.BorderRadius ) )};" )
                 .AppendLine( "}" );
 
+            sb.Append( $".ant-card-cover:first-child" ).Append( "{" )
+                .Append( $"border-top-left-radius: {GetBorderRadius( theme, options?.BorderRadius, Var( ThemeVariables.BorderRadius ) )};" )
+                .Append( $"border-top-right-radius: {GetBorderRadius( theme, options?.BorderRadius, Var( ThemeVariables.BorderRadius ) )};" )
+                .AppendLine( "}" );
+
+            sb.Append( $".ant-card-cover:last-child" ).Append( "{" )
+                .Append( $"border-bottom-left-radius: {GetBorderRadius( theme, options?.BorderRadius, Var( ThemeVariables.BorderRadius ) )};" )
+                .Append( $"border-bottom-right-radius: {GetBorderRadius( theme, options?.BorderRadius, Var( ThemeVariables.BorderRadius ) )};" )
+                .AppendLine( "}" );
+
             if ( !string.IsNullOrEmpty( options?.ImageTopRadius ) )
                 sb.Append( $".ant-card-cover" ).Append( "{" )
                     .Append( $"border-top-left-radius: {options.ImageTopRadius};" )

--- a/Source/Blazorise.AntDesign/Styles/_card.scss
+++ b/Source/Blazorise.AntDesign/Styles/_card.scss
@@ -27,5 +27,13 @@
 img.ant-card-cover {
     display: block;
     width: 100%;
-    border-radius: 2px 2px 0 0;
+    margin-left: 0px;
+
+    &:first-child {
+        border-radius: .25rem .25rem 0 0;
+    }
+
+    &:last-child {
+        border-radius: 0 0 .25rem .25rem;
+    }
 }

--- a/Source/Blazorise.AntDesign/Styles/_card.scss
+++ b/Source/Blazorise.AntDesign/Styles/_card.scss
@@ -24,16 +24,8 @@
     margin-bottom: 0;
 }
 
-img.ant-card-cover {
+.ant-card-cover {
     display: block;
     width: 100%;
     margin-left: 0px;
-
-    &:first-child {
-        border-radius: .25rem .25rem 0 0;
-    }
-
-    &:last-child {
-        border-radius: 0 0 .25rem .25rem;
-    }
 }

--- a/Source/Blazorise.AntDesign/Styles/_card.scss
+++ b/Source/Blazorise.AntDesign/Styles/_card.scss
@@ -23,3 +23,9 @@
     margin-top: -.375rem;
     margin-bottom: 0;
 }
+
+img.ant-card-cover {
+    display: block;
+    width: 100%;
+    border-radius: 2px 2px 0 0;
+}

--- a/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
+++ b/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
@@ -60,14 +60,10 @@
     margin-top: -.375rem;
     margin-bottom: 0; }
 
-img.ant-card-cover {
+.ant-card-cover {
     display: block;
     width: 100%;
     margin-left: 0px; }
-    img.ant-card-cover:first-child {
-        border-radius: .25rem .25rem 0 0; }
-    img.ant-card-cover:last-child {
-        border-radius: 0 0 .25rem .25rem; }
 
 .ant-modal {
     width: 520px; }

--- a/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
+++ b/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
@@ -60,6 +60,11 @@
     margin-top: -.375rem;
     margin-bottom: 0; }
 
+img.ant-card-cover {
+    display: block;
+    width: 100%;
+    border-radius: 2px 2px 0 0; }
+
 .ant-modal {
     width: 520px; }
     @media (min-width: 576px) {

--- a/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
+++ b/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
@@ -63,7 +63,11 @@
 img.ant-card-cover {
     display: block;
     width: 100%;
-    border-radius: 2px 2px 0 0; }
+    margin-left: 0px; }
+    img.ant-card-cover:first-child {
+        border-radius: .25rem .25rem 0 0; }
+    img.ant-card-cover:last-child {
+        border-radius: 0 0 .25rem .25rem; }
 
 .ant-modal {
     width: 520px; }


### PR DESCRIPTION
Since Ant Design has the concept of a `Cover` element for `Card` which is structured like the following:

```
<div class="ant-card-cover">
  <img ... />
</div>
```

This class `.ant-card-cover` applies additional styling to the child elements.
These are missed in Blazorise.

Since Blazorise has `CardImage` as its equivalent (without the parent class) I have added the additional CSS directly to the `<img ... />` element that has the `.ant-card-cover` class.

Example of Ant Design CSS can be found [here.](https://github.com/ant-design/ant-design/blob/master/components/card/style/index.less#L132)

**Edit:**
Moved this CSS once I saw it is partially covered in the `ThemeGenerator` (still learning about Blazorise code structure!)

I think that the `Top` and `Bottom` `img` elements of the `Card` should follow Ant Design and always have radius that matches the `Card`.

However, I have left the `options?.ImageTopRadius` untouched, this can be used to override the default I am suggesting.