### PR TITLE
[AntDesign] fix: progress bar

### DIFF
--- a/Source/Blazorise.AntDesign/AntDesignClassProvider.cs
+++ b/Source/Blazorise.AntDesign/AntDesignClassProvider.cs
@@ -671,7 +671,7 @@ namespace Blazorise.AntDesign
 
         public override string ProgressSize( Size size ) => $"progress-{ToSize( size )}";
 
-        public override string ProgressBar() => "ant-progress-bg";
+        public override string ProgressBar() => "ant-progress-bg b-ant-progress-text";
 
         public override string ProgressBarColor( Background background ) => BackgroundColor( background );
 

--- a/Source/Blazorise.AntDesign/AntDesignStyleProvider.cs
+++ b/Source/Blazorise.AntDesign/AntDesignStyleProvider.cs
@@ -23,7 +23,7 @@ namespace Blazorise.AntDesign
 
         #region ProgressBar
 
-        public override string ProgressBarValue( int value ) => $"width: {value}%; display: inline-block";
+        public override string ProgressBarValue( int value ) => $"width: {value}%";
 
         public override string ProgressBarSize( Size size )
         {

--- a/Source/Blazorise.AntDesign/Styles/_progress.scss
+++ b/Source/Blazorise.AntDesign/Styles/_progress.scss
@@ -1,0 +1,3 @@
+﻿.ant-progress-inner {
+    display: inline-flex;
+}

--- a/Source/Blazorise.AntDesign/Styles/_progress.scss
+++ b/Source/Blazorise.AntDesign/Styles/_progress.scss
@@ -1,3 +1,11 @@
 ﻿.ant-progress-inner {
     display: inline-flex;
 }
+
+.b-ant-progress-text {
+    text-align: center;
+    display: flex;
+    color: #fff;
+    justify-content: center;
+    flex-direction: column;
+}

--- a/Source/Blazorise.AntDesign/Styles/blazorise.antdesign.scss
+++ b/Source/Blazorise.AntDesign/Styles/blazorise.antdesign.scss
@@ -17,5 +17,6 @@
 @import "alert";
 @import "figure";
 @import "layout";
+@import "progress";
 
 @import "utilities";

--- a/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
+++ b/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
@@ -352,6 +352,9 @@
 .b-body-layout {
     overflow-x: hidden; }
 
+.ant-progress-inner {
+    display: inline-flex; }
+
 .m-xs-0 {
     margin: 0 !important; }
 

--- a/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
+++ b/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
@@ -355,6 +355,13 @@
 .ant-progress-inner {
     display: inline-flex; }
 
+.b-ant-progress-text {
+    text-align: center;
+    display: flex;
+    color: #fff;
+    justify-content: center;
+    flex-direction: column; }
+
 .m-xs-0 {
     margin: 0 !important; }
 


### PR DESCRIPTION
There was an issue with the Ant Design progress bar background taking up too much vertical space:
![image](https://user-images.githubusercontent.com/6387861/79287808-13201100-7f19-11ea-8e32-3a7991bad5e1.png)

I have fixed it to the following: 
![image](https://user-images.githubusercontent.com/6387861/79287983-8cb7ff00-7f19-11ea-981d-e579af3e204f.png)

**Edit:**
Additionally, I have also added better styling for the `ProgressBar` inner text on Ant Design.

Was:
![image](https://user-images.githubusercontent.com/6387861/79288843-f0432c00-7f1b-11ea-9a40-12b5ce60c8a4.png)


Now:
![image](https://user-images.githubusercontent.com/6387861/79288799-cc7fe600-7f1b-11ea-8658-380610e488fd.png)

However, since this is non-standard of Ant Design, I have put this styling in a new "Blazorise" specific class `.b-ant-progress-text`