### PR TITLE
fix: Ant Desgin TableRowHeader

### DIFF
--- a/Source/Blazorise.AntDesign/AntDesignClassProvider.cs
+++ b/Source/Blazorise.AntDesign/AntDesignClassProvider.cs
@@ -751,7 +751,7 @@ namespace Blazorise.AntDesign
 
         public override string TableRowIsSelected() => "selected";
 
-        public override string TableRowHeader() => null;
+        public override string TableRowHeader() => "ant-table-cell b-ant-row-header";
 
         public override string TableRowCell() => "ant-table-cell";
 

--- a/Source/Blazorise.AntDesign/AntDesignClassProvider.cs
+++ b/Source/Blazorise.AntDesign/AntDesignClassProvider.cs
@@ -751,7 +751,7 @@ namespace Blazorise.AntDesign
 
         public override string TableRowIsSelected() => "selected";
 
-        public override string TableRowHeader() => "ant-table-cell b-ant-row-header";
+        public override string TableRowHeader() => "ant-table-cell ant-table-row-header";
 
         public override string TableRowCell() => "ant-table-cell";
 

--- a/Source/Blazorise.AntDesign/Config.cs
+++ b/Source/Blazorise.AntDesign/Config.cs
@@ -81,6 +81,7 @@ namespace Blazorise.AntDesign
             componentMapper.Register<Blazorise.TabPanel, AntDesign.TabPanel>();
             componentMapper.Register<Blazorise.TabsContent, AntDesign.TabsContent>();
             componentMapper.Register<Blazorise.Table, AntDesign.Table>();
+            componentMapper.Register<Blazorise.TableRowHeader, AntDesign.TableRowHeader>();
             componentMapper.Register<Blazorise.TextEdit, AntDesign.TextEdit>();
         }
 

--- a/Source/Blazorise.AntDesign/Styles/_table.scss
+++ b/Source/Blazorise.AntDesign/Styles/_table.scss
@@ -48,6 +48,6 @@
     }
 }
 
-.b-ant-row-header {
+.ant-table-row-header {
     font-weight: bold;
 }

--- a/Source/Blazorise.AntDesign/Styles/_table.scss
+++ b/Source/Blazorise.AntDesign/Styles/_table.scss
@@ -47,3 +47,7 @@
         }
     }
 }
+
+.b-ant-row-header {
+    font-weight: bold;
+}

--- a/Source/Blazorise.AntDesign/TableRowHeader.razor
+++ b/Source/Blazorise.AntDesign/TableRowHeader.razor
@@ -1,0 +1,4 @@
+﻿@inherits Blazorise.TableRowHeader
+<td class="@ClassNames" style="@StyleNames" @onclick="@HandleClick" @attributes="@Attributes">
+    @ChildContent
+</td>

--- a/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
+++ b/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
@@ -165,6 +165,9 @@
     background-color: var(--b-table-thead-light-background, #e9ecef);
     border-color: var(--b-table-thead-light-border, #e9ecef); }
 
+.b-ant-row-header {
+    font-weight: bold; }
+
 .ant-menu-submenu-horizontal > .ant-menu-submenu-title .ant-menu-submenu-arrow {
     position: absolute;
     top: 50%;

--- a/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
+++ b/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
@@ -165,7 +165,7 @@
     background-color: var(--b-table-thead-light-background, #e9ecef);
     border-color: var(--b-table-thead-light-border, #e9ecef); }
 
-.b-ant-row-header {
+.ant-table-row-header {
     font-weight: bold; }
 
 .ant-menu-submenu-horizontal > .ant-menu-submenu-title .ant-menu-submenu-arrow {


### PR DESCRIPTION
One last Ant Design fix before **0.9.0** from me!

Ant Design does not seem to support `th` tags in the `tbody` element rows (`TableRowHeader` component).

It was looking like:
![image](https://user-images.githubusercontent.com/6387861/79511306-27881900-8093-11ea-9ce4-fcb1889a58af.png)

I have updated them to be `td` elements for Ant Design and created a custom CSS class for `bold`.
![image](https://user-images.githubusercontent.com/6387861/79511346-3ff83380-8093-11ea-9290-3dcd7490a6dd.png)
