### PR TITLE
fix: modified launchSettings.json and removed CodeCoverage reference

### DIFF
--- a/Tests/BasicTestApp.Client/Properties/launchSettings.json
+++ b/Tests/BasicTestApp.Client/Properties/launchSettings.json
@@ -11,6 +11,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -18,6 +19,7 @@
     "Blazorise.BasicTestApp.Client": {
       "commandName": "Project",
       "launchBrowser": true,
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/Tests/BasicTestApp.Server/Properties/launchSettings.json
+++ b/Tests/BasicTestApp.Server/Properties/launchSettings.json
@@ -11,6 +11,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -18,6 +19,7 @@
     "Blazorise.BasicTestApp.Server": {
       "commandName": "Project",
       "launchBrowser": true,
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/Tests/Blazorise.E2ETests/Blazorise.E2ETests.csproj
+++ b/Tests/Blazorise.E2ETests/Blazorise.E2ETests.csproj
@@ -26,7 +26,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="3.2.0-preview4.20210.8" />
-    <PackageReference Include="Microsoft.CodeCoverage" Version="16.5.0" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/Tests/Blazorise.E2ETests/Properties/launchSettings.json
+++ b/Tests/Blazorise.E2ETests/Properties/launchSettings.json
@@ -11,6 +11,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -18,6 +19,7 @@
     "Blazorise.UnitTests": {
       "commandName": "Project",
       "launchBrowser": true,
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/Tests/Blazorise.E2ETests/package.json
+++ b/Tests/Blazorise.E2ETests/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "blazorise.unittests",
+  "name": "blazorise.e2etests",
   "version": "0.0.1",
   "description": "Not a real package. This file exists only to declare dependencies.",
   "main": "index.js",


### PR DESCRIPTION
Tests were falling, and adding `"inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",` to `launchSettings.json` helped.