### PR TITLE
Additional fixes for responsive Layout

### DIFF
--- a/Demos/Blazorise.Demo/Layouts/MainLayout.razor
+++ b/Demos/Blazorise.Demo/Layouts/MainLayout.razor
@@ -170,7 +170,7 @@
                 </BarMenu>
             </Bar>
         </LayoutHeader>
-        <LayoutContent Padding="Padding.Is4.OnX">
+        <LayoutContent Padding="Padding.Is4.OnX" Style="margin-top: 64px">
             @Body
         </LayoutContent>
     </Layout>

--- a/Source/Blazorise.AntDesign/Styles/_layout.scss
+++ b/Source/Blazorise.AntDesign/Styles/_layout.scss
@@ -1,7 +1,3 @@
 ﻿.b-layout-header {
     line-height: 64px;
 }
-
-.b-body-layout {
-    overflow-x: hidden;
-}

--- a/Source/Blazorise.Bootstrap/Styles/_layout.scss
+++ b/Source/Blazorise.Bootstrap/Styles/_layout.scss
@@ -1,3 +1,1 @@
-﻿.b-body-layout {
-    overflow-x: hidden;
-}
+﻿

--- a/Source/Blazorise.Frolic/Styles/_layout.scss
+++ b/Source/Blazorise.Frolic/Styles/_layout.scss
@@ -1,3 +1,1 @@
-﻿.b-body-layout {
-    overflow-x: hidden;
-}
+﻿

--- a/Source/Blazorise.Material/Styles/_layout.scss
+++ b/Source/Blazorise.Material/Styles/_layout.scss
@@ -1,3 +1,1 @@
-﻿.b-body-layout {
-    overflow-x: hidden;
-}
+﻿

--- a/Source/Blazorise/ClassProvider.cs
+++ b/Source/Blazorise/ClassProvider.cs
@@ -394,8 +394,6 @@ namespace Blazorise
 
         public virtual string LayoutHasSider() => "b-layout-has-sider";
 
-        public virtual string LayoutBody() => "b-body-layout";
-
         public virtual string LayoutContent() => "b-layout-content";
 
         public virtual string LayoutHeader() => "b-layout-header";

--- a/Source/Blazorise/IClassProvider.cs
+++ b/Source/Blazorise/IClassProvider.cs
@@ -393,8 +393,6 @@ namespace Blazorise
 
         string LayoutHasSider();
 
-        string LayoutBody();
-
         string LayoutContent();
 
         string LayoutHeader();

--- a/Source/Blazorise/Layout.razor.cs
+++ b/Source/Blazorise/Layout.razor.cs
@@ -28,36 +28,6 @@ namespace Blazorise
             base.BuildClasses( builder );
         }
 
-        protected override async Task OnAfterRenderAsync( bool firstRender )
-        {
-            if ( firstRender )
-            {
-                if ( ParentLayout == null )
-                {
-                    await JSRunner.AddClassToBody( ClassProvider.LayoutBody() );
-
-                    bodyClassApplied = true;
-                }
-            }
-
-            await base.OnAfterRenderAsync( firstRender );
-        }
-
-        protected override void Dispose( bool disposing )
-        {
-            if ( disposing )
-            {
-                if ( bodyClassApplied )
-                {
-                    _ = JSRunner.RemoveClassFromBody( ClassProvider.LayoutBody() );
-
-                    bodyClassApplied = false;
-                }
-            }
-
-            base.Dispose( disposing );
-        }
-
         #endregion
 
         #region Properties

--- a/Source/Blazorise/Styles/_layout.scss
+++ b/Source/Blazorise/Styles/_layout.scss
@@ -36,7 +36,7 @@
         position: fixed;
         z-index: 1;
         top: 0;
-        width: calc(100% - 220px);
+        width: calc(100% - var(--b-sidebar-width, 0px));
 
         @media (min-width:1px) and (max-width:767.98px) {
             width: 100%;

--- a/Source/Blazorise/Styles/_layout.scss
+++ b/Source/Blazorise/Styles/_layout.scss
@@ -16,7 +16,6 @@
 
         .b-layout {
             overflow-x: hidden;
-            margin-top: 64px;
         }
     }
 }

--- a/Source/Blazorise/Styles/_layout.scss
+++ b/Source/Blazorise/Styles/_layout.scss
@@ -16,6 +16,7 @@
 
         .b-layout {
             overflow-x: hidden;
+            margin-top: 64px;
         }
     }
 }
@@ -32,9 +33,14 @@
     /*background: #001529;*/
     /*line-height: 64px;*/
     &-fixed {
-        position: sticky;
+        position: fixed;
         z-index: 1;
         top: 0;
+        width: calc(100% - 220px);
+
+        @media (min-width:1px) and (max-width:767.98px) {
+            width: 100%;
+        }
     }
 }
 

--- a/Source/Blazorise/Theme.cs
+++ b/Source/Blazorise/Theme.cs
@@ -507,9 +507,11 @@ namespace Blazorise
 
     public class ThemeSidebarOptions
     {
-        public string BackgroundColor { get; set; }
+        public string Width { get; set; } = "220px";
 
-        public string Color { get; set; }
+        public string BackgroundColor { get; set; } = "#343a40";
+
+        public string Color { get; set; } = "#ced4da";
     }
 
     public class ThemeSnackbarOptions
@@ -591,6 +593,7 @@ namespace Blazorise
         public static string OutlineButtonYiqColor( string variant ) => $"--b-outline-button-{variant}-yiq-shadow";
         public static string OutlineButtonBoxShadowColor( string variant ) => $"--b-outline-button-{variant}-box-shadow";
 
+        public const string SidebarWidth = "--b-sidebar-width";
         public const string SidebarBackground = "--b-sidebar-background";
         public const string SidebarColor = "--b-sidebar-color";
 

--- a/Source/Blazorise/ThemeGenerator.cs
+++ b/Source/Blazorise/ThemeGenerator.cs
@@ -195,6 +195,9 @@ namespace Blazorise
 
         protected virtual void GenerateSidebarVariables( ThemeSidebarOptions sidebarOptions )
         {
+            if ( sidebarOptions.Width != null )
+                variables[ThemeVariables.SidebarWidth] = sidebarOptions.Width;
+
             if ( sidebarOptions.BackgroundColor != null )
                 variables[ThemeVariables.SidebarBackground] = ToHex( ParseColor( sidebarOptions.BackgroundColor ) );
 

--- a/Source/Blazorise/wwwroot/blazorise.css
+++ b/Source/Blazorise/wwwroot/blazorise.css
@@ -153,7 +153,8 @@
 .b-layout.b-layout-has-sider {
     flex-direction: row; }
     .b-layout.b-layout-has-sider .b-layout {
-        overflow-x: hidden; }
+        overflow-x: hidden;
+        margin-top: 64px; }
 
 .b-layout-header,
 .b-layout-footer {
@@ -166,9 +167,13 @@
     /*background: #001529;*/
     /*line-height: 64px;*/ }
     .b-layout-header-fixed {
-        position: sticky;
+        position: fixed;
         z-index: 1;
-        top: 0; }
+        top: 0;
+        width: calc(100% - 220px); }
+        @media (min-width: 1px) and (max-width: 767.98px) {
+            .b-layout-header-fixed {
+                width: 100%; } }
 
 .b-layout-footer {
     /*padding: 24px 50px;*/

--- a/Source/Blazorise/wwwroot/blazorise.css
+++ b/Source/Blazorise/wwwroot/blazorise.css
@@ -170,7 +170,7 @@
         position: fixed;
         z-index: 1;
         top: 0;
-        width: calc(100% - 220px); }
+        width: calc(100% - var(--b-sidebar-width, 0px)); }
         @media (min-width: 1px) and (max-width: 767.98px) {
             .b-layout-header-fixed {
                 width: 100%; } }

--- a/Source/Blazorise/wwwroot/blazorise.css
+++ b/Source/Blazorise/wwwroot/blazorise.css
@@ -153,8 +153,7 @@
 .b-layout.b-layout-has-sider {
     flex-direction: row; }
     .b-layout.b-layout-has-sider .b-layout {
-        overflow-x: hidden;
-        margin-top: 64px; }
+        overflow-x: hidden; }
 
 .b-layout-header,
 .b-layout-footer {

--- a/Source/Extensions/Blazorise.Sidebar/wwwroot/blazorise.sidebar.css
+++ b/Source/Extensions/Blazorise.Sidebar/wwwroot/blazorise.sidebar.css
@@ -1,9 +1,13 @@
-﻿.sidebar {
+﻿:root {
+    --b-sidebar-width: 220px;
+}
+
+.sidebar {
     --bsb-dark: var(--b-sidebar-background, #343a40);
     --bsb-dark-dark: var(--b-sidebar-background, #343a40);
     --bsb-dark-light: var(--b-sidebar-color, #ced4da);
-    min-width: 220px;
-    max-width: 220px;
+    min-width: var(--b-sidebar-width, 220px);
+    max-width: var(--b-sidebar-width, 220px);
     min-height: 100vh;
     transition: margin .4s ease-in-out;
     z-index: 2;
@@ -30,7 +34,7 @@
     position: fixed;
     top: 0;
     z-index: 2;
-    width: 220px;
+    width: var(--b-sidebar-width, 220px);
 }
 
 .sidebar-nav {
@@ -141,11 +145,11 @@
 }
 
 .sidebar:not(.sidebar-collapsed).show {
-    margin-left: -220px;
+    margin-left: -var(--b-sidebar-width, 220px);
 }
 
 .sidebar-collapsed.show {
-    margin-left: -220px;
+    margin-left: -var(--b-sidebar-width, 220px);
 }
 
 html[data-useragent*="MSIE 10.0"] .show.sidebar-collapsed {
@@ -166,8 +170,8 @@ html[data-useragent*="MSIE 10.0"] .show.sidebar-collapsed {
     bottom: 0;
     position: fixed;
     background: var(--bsb-dark-dark);
-    min-width: 220px;
-    max-width: 220px;
+    min-width: var(--b-sidebar-width, 220px);
+    max-width: var(--b-sidebar-width, 220px);
     color: #e9ecef;
     z-index: 3;
 }
@@ -188,7 +192,7 @@ html[data-useragent*="MSIE 10.0"] .show.sidebar-collapsed {
 
 @media (min-width:1px) and (max-width:767.98px) {
     .sidebar:not(.sidebar-collapsed) {
-        margin-left: -220px;
+        margin-left: -var(--b-sidebar-width, 220px);
     }
 
         .sidebar:not(.sidebar-collapsed).show {


### PR DESCRIPTION
@stsrki until [this CSS issue](https://github.com/w3c/csswg-drafts/issues/865) is fixed, we cannot use `position: sticky` header **and** `overflow-x: hidden` on `Layout` elements. `overflow-x: hidden` is required for responsive to work well within the `Layout` elements.

Since responsiveness is more important.. I have made workaround for the `sticky` header by using `fixed` and calculating the offset of the `Sidebar` (in `_layout.scss`).

This isn't perfect for all situations and would be better if the offset calculation was tied to the `margin` of the `Sidebar` (but this requires more JSInterop knowledge than I have!)

**Also**, removed the now un-need `.b-body-layout`.. which is a win.