### PR TITLE
Fixes for SidebarItem

### DIFF
--- a/Demos/Blazorise.Demo/Layouts/MainLayout.razor
+++ b/Demos/Blazorise.Demo/Layouts/MainLayout.razor
@@ -17,10 +17,10 @@
                             </SidebarLink>
                         </SidebarItem>
                         <SidebarItem>
-                            <SidebarLink Toggled="(isOpen)=> sidebarSubItemUIElement.Toggle(isOpen)" Visible="true">
+                            <SidebarLink Toggled="@((isOpen)=> uiElementsSubItemVisible = isOpen)" Visible="@uiElementsSubItemVisible">
                                 <Icon Name="IconName.Edit" Margin="Margin.Is3.FromRight" />UI Elements
                             </SidebarLink>
-                            <SidebarSubItem @ref="sidebarSubItemUIElement" Visible="true">
+                            <SidebarSubItem Visible="@uiElementsSubItemVisible">
                                 <SidebarItem>
                                     <SidebarLink To="tests/buttons">Buttons</SidebarLink>
                                 </SidebarItem>
@@ -57,10 +57,10 @@
                             </SidebarSubItem>
                         </SidebarItem>
                         <SidebarItem>
-                            <SidebarLink Toggled="(isOpen)=> sidebarSubItemForms.Toggle(isOpen)">
+                            <SidebarLink Toggled="@((isOpen)=> formsSubItemVisible = isOpen)" Visible="@formsSubItemVisible">
                                 <Icon Name="IconName.Edit" Margin="Margin.Is3.FromRight" />Forms
                             </SidebarLink>
-                            <SidebarSubItem @ref="sidebarSubItemForms" Visible="@formsSubItemVisible">
+                            <SidebarSubItem Visible="@formsSubItemVisible">
                                 <SidebarItem>
                                     <SidebarLink To="tests/forms">Forms</SidebarLink>
                                 </SidebarItem>
@@ -70,10 +70,10 @@
                             </SidebarSubItem>
                         </SidebarItem>
                         <SidebarItem>
-                            <SidebarLink Toggled="(isOpen)=> sidebarSubItemExtensions.Toggle(isOpen)">
+                            <SidebarLink Toggled="@((isOpen)=> extensionsSubItemVisible = isOpen)" Visible="@extensionsSubItemVisible">
                                 <Icon Name="IconName.Edit" Margin="Margin.Is3.FromRight" />Extensions
                             </SidebarLink>
-                            <SidebarSubItem @ref="sidebarSubItemExtensions">
+                            <SidebarSubItem Visible="@extensionsSubItemVisible">
                                 <SidebarItem>
                                     <SidebarLink To="tests/datagrid">DataGrid</SidebarLink>
                                 </SidebarItem>
@@ -89,10 +89,10 @@
                             </SidebarSubItem>
                         </SidebarItem>
                         <SidebarItem>
-                            <SidebarLink Toggled="(isOpen)=> sidebarSubItemApps.Toggle(isOpen)">
+                            <SidebarLink Toggled="@((isOpen)=> appsSubItemVisible = isOpen)" Visible="@appsSubItemVisible">
                                 <Icon Name="IconName.Smartphone" Margin="Margin.Is3.FromRight" />Apps
                             </SidebarLink>
-                            <SidebarSubItem @ref="sidebarSubItemApps">
+                            <SidebarSubItem Visible="@appsSubItemVisible">
                                 <SidebarItem>
                                     <SidebarLink To="apps/todo">Todo List</SidebarLink>
                                 </SidebarItem>
@@ -261,12 +261,11 @@
     }
 
     Sidebar sidebar;
-    SidebarSubItem sidebarSubItemUIElement;
-    SidebarSubItem sidebarSubItemForms;
-    SidebarSubItem sidebarSubItemExtensions;
-    SidebarSubItem sidebarSubItemApps;
 
+    bool uiElementsSubItemVisible = true;
     bool formsSubItemVisible = true;
+    bool extensionsSubItemVisible = false;
+    bool appsSubItemVisible = false;
 
     //bool collapseNavMenu = true;
 

--- a/Source/Extensions/Blazorise.Sidebar/Sidebar.razor
+++ b/Source/Extensions/Blazorise.Sidebar/Sidebar.razor
@@ -1,4 +1,4 @@
-﻿@inherits BaseSidebar
+﻿@inherits BaseComponent
 <nav class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
     @if ( Data != null )
     {

--- a/Source/Extensions/Blazorise.Sidebar/Sidebar.razor.cs
+++ b/Source/Extensions/Blazorise.Sidebar/Sidebar.razor.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazorise.Sidebar
 {
-    public abstract class BaseSidebar : BaseComponent
+    public partial class Sidebar : BaseComponent
     {
         #region Members
 

--- a/Source/Extensions/Blazorise.Sidebar/SidebarBrand.razor
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarBrand.razor
@@ -1,4 +1,4 @@
-﻿@inherits BaseSidebarBrand
+﻿@inherits BaseComponent
 <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
     @ChildContent
 </div>

--- a/Source/Extensions/Blazorise.Sidebar/SidebarBrand.razor.cs
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarBrand.razor.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazorise.Sidebar
 {
-    public abstract class BaseSidebarBrand : BaseComponent
+    public partial class SidebarBrand : BaseComponent
     {
         #region Members
 

--- a/Source/Extensions/Blazorise.Sidebar/SidebarContent.razor
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarContent.razor
@@ -1,4 +1,4 @@
-﻿@inherits BaseSidebarContent
+﻿@inherits BaseComponent
 <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
     @ChildContent
 </div>

--- a/Source/Extensions/Blazorise.Sidebar/SidebarContent.razor.cs
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarContent.razor.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazorise.Sidebar
 {
-    public abstract class BaseSidebarContent : BaseComponent
+    public partial class SidebarContent : BaseComponent
     {
         #region Members
 

--- a/Source/Extensions/Blazorise.Sidebar/SidebarFooter.razor
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarFooter.razor
@@ -1,4 +1,4 @@
-﻿@inherits BaseSidebarFooter
+﻿@inherits BaseComponent
 <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
     @ChildContent
 </div>

--- a/Source/Extensions/Blazorise.Sidebar/SidebarFooter.razor.cs
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarFooter.razor.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazorise.Sidebar
 {
-    public abstract class BaseSidebarFooter : BaseComponent
+    public partial class SidebarFooter : BaseComponent
     {
         #region Members
 

--- a/Source/Extensions/Blazorise.Sidebar/SidebarItem.razor
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarItem.razor
@@ -1,4 +1,4 @@
-﻿@inherits BaseSidebarItem
+﻿@inherits BaseComponent
 <CascadingValue Value=this>
     <li class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
         @ChildContent

--- a/Source/Extensions/Blazorise.Sidebar/SidebarItem.razor
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarItem.razor
@@ -1,4 +1,6 @@
 ﻿@inherits BaseSidebarItem
-<li class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-    @ChildContent
-</li>
+<CascadingValue Value=this>
+    <li class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+        @ChildContent
+    </li>
+</CascadingValue>

--- a/Source/Extensions/Blazorise.Sidebar/SidebarItem.razor.cs
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarItem.razor.cs
@@ -12,6 +12,10 @@ namespace Blazorise.Sidebar
     {
         #region Members
 
+        private bool hasLink;
+
+        private bool hasSubItem;
+
         #endregion
 
         #region Methods
@@ -23,9 +27,23 @@ namespace Blazorise.Sidebar
             base.BuildClasses( builder );
         }
 
+        internal void NotifyHasSidebarLink()
+        {
+            hasLink = true;
+        }
+
+        internal void NotifyHasSidebarSubItem()
+        {
+            hasSubItem = true;
+        }
+
         #endregion
 
         #region Properties
+
+        public bool HasLink => hasLink;
+
+        public bool HasSubItem => hasSubItem;
 
         [Parameter] public RenderFragment ChildContent { get; set; }
 

--- a/Source/Extensions/Blazorise.Sidebar/SidebarItem.razor.cs
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarItem.razor.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazorise.Sidebar
 {
-    public abstract class BaseSidebarItem : BaseComponent
+    public partial class SidebarItem : BaseComponent
     {
         #region Members
 

--- a/Source/Extensions/Blazorise.Sidebar/SidebarLabel.razor
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarLabel.razor
@@ -1,4 +1,4 @@
-﻿@inherits BaseSidebarLabel
+﻿@inherits BaseComponent
 <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
     @ChildContent
 </div>

--- a/Source/Extensions/Blazorise.Sidebar/SidebarLabel.razor.cs
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarLabel.razor.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazorise.Sidebar
 {
-    public abstract class BaseSidebarLabel : BaseComponent
+    public partial class SidebarLabel : BaseComponent
     {
         #region Members
 

--- a/Source/Extensions/Blazorise.Sidebar/SidebarLink.razor
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarLink.razor
@@ -7,7 +7,7 @@
 }
 else
 {
-    <a class="@ClassNames" style="@StyleNames" @onclick="@ClickHandler" data-toggle="sidebar-collapse" aria-expanded="@Visible" title="@Title" @attributes="@Attributes">
+    <a class="@ClassNames" style="@StyleNames" @onclick="@ClickHandler" data-toggle="@DataToggle" aria-expanded="@AriaExpanded" title="@Title" @attributes="@Attributes">
         @ChildContent
     </a>
 }

--- a/Source/Extensions/Blazorise.Sidebar/SidebarLink.razor
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarLink.razor
@@ -1,4 +1,4 @@
-﻿@inherits BaseSidebarLink
+﻿@inherits BaseComponent
 @if ( To != null )
 {
     <Blazorise.Link Class="@ClassNames" Style="@StyleNames" To="@To" Title="@Title" Match="@Match" Attributes="@Attributes">

--- a/Source/Extensions/Blazorise.Sidebar/SidebarLink.razor.cs
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarLink.razor.cs
@@ -21,16 +21,26 @@ namespace Blazorise.Sidebar
         protected override void BuildClasses( ClassBuilder builder )
         {
             builder.Append( "sidebar-link" );
-            builder.Append( "collapsed", !Visible );
+            builder.Append( "collapsed", Collapsable && !Visible );
 
             base.BuildClasses( builder );
         }
 
-        protected void ClickHandler()
+        protected override void OnInitialized()
         {
-            Click?.Invoke();
+            if ( ParentSidebarItem != null )
+            {
+                ParentSidebarItem.NotifyHasSidebarLink();
+            }
 
-            if ( To == null )
+            base.OnInitialized();
+        }
+
+        protected async Task ClickHandler()
+        {
+            await Click.InvokeAsync( null );
+
+            if ( Collapsable )
             {
                 Visible = !Visible;
 
@@ -43,6 +53,12 @@ namespace Blazorise.Sidebar
         #endregion
 
         #region Properties
+
+        protected bool Collapsable => ParentSidebarItem?.HasSubItem == true;
+
+        protected string DataToggle => Collapsable ? "sidebar-collapse" : null;
+
+        protected string AriaExpanded => Collapsable ? Visible.ToString().ToLowerInvariant() : null;
 
         [Parameter]
         public bool Visible
@@ -65,9 +81,11 @@ namespace Blazorise.Sidebar
         /// <summary>
         /// Occurs when the item is clicked.
         /// </summary>
-        [Parameter] public Action Click { get; set; }
+        [Parameter] public EventCallback Click { get; set; }
 
         [Parameter] public Action<bool> Toggled { get; set; }
+
+        [CascadingParameter] public SidebarItem ParentSidebarItem { get; set; }
 
         [Parameter] public RenderFragment ChildContent { get; set; }
 

--- a/Source/Extensions/Blazorise.Sidebar/SidebarLink.razor.cs
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarLink.razor.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazorise.Sidebar
 {
-    public abstract class BaseSidebarLink : BaseComponent
+    public partial class SidebarLink : BaseComponent
     {
         #region Members
 

--- a/Source/Extensions/Blazorise.Sidebar/SidebarLink.razor.cs
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarLink.razor.cs
@@ -46,7 +46,7 @@ namespace Blazorise.Sidebar
 
                 StateHasChanged();
 
-                Toggled?.Invoke( Visible );
+                await Toggled.InvokeAsync( Visible );
             }
         }
 
@@ -83,7 +83,7 @@ namespace Blazorise.Sidebar
         /// </summary>
         [Parameter] public EventCallback Click { get; set; }
 
-        [Parameter] public Action<bool> Toggled { get; set; }
+        [Parameter] public EventCallback<bool> Toggled { get; set; }
 
         [CascadingParameter] public SidebarItem ParentSidebarItem { get; set; }
 

--- a/Source/Extensions/Blazorise.Sidebar/SidebarNavigation.razor
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarNavigation.razor
@@ -1,4 +1,4 @@
-﻿@inherits BaseSidebarNavigation
+﻿@inherits BaseComponent
 <ul class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
     @ChildContent
 </ul>

--- a/Source/Extensions/Blazorise.Sidebar/SidebarNavigation.razor.cs
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarNavigation.razor.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazorise.Sidebar
 {
-    public abstract class BaseSidebarNavigation : BaseComponent
+    public partial class SidebarNavigation : BaseComponent
     {
         #region Members
 

--- a/Source/Extensions/Blazorise.Sidebar/SidebarSubItem.razor
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarSubItem.razor
@@ -1,4 +1,4 @@
-﻿@inherits BaseSidebarSubItem
+﻿@inherits BaseComponent
 <ul class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
     @ChildContent
 </ul>

--- a/Source/Extensions/Blazorise.Sidebar/SidebarSubItem.razor.cs
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarSubItem.razor.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazorise.Sidebar
 {
-    public abstract class BaseSidebarSubItem : BaseComponent
+    public partial class SidebarSubItem : BaseComponent
     {
         #region Members
 

--- a/Source/Extensions/Blazorise.Sidebar/SidebarSubItem.razor.cs
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarSubItem.razor.cs
@@ -1,6 +1,7 @@
 ﻿#region Using directives
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.Design;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
@@ -24,6 +25,16 @@ namespace Blazorise.Sidebar
             builder.Append( "show", Visible );
 
             base.BuildClasses( builder );
+        }
+
+        protected override void OnInitialized()
+        {
+            if ( ParentSidebarItem != null )
+            {
+                ParentSidebarItem.NotifyHasSidebarSubItem();
+            }
+
+            base.OnInitialized();
         }
 
         /// <summary>
@@ -52,6 +63,8 @@ namespace Blazorise.Sidebar
                 DirtyClasses();
             }
         }
+
+        [CascadingParameter] public SidebarItem ParentSidebarItem { get; set; }
 
         [Parameter] public RenderFragment ChildContent { get; set; }
 


### PR DESCRIPTION
#795 Bug: SidebarLink with Clicked event behaves as an expandable node

Fixes include:

- Expandable icon does not show if there is no subitems
- Click and Toggled events converted to EventCallback
- All Sidebar components converted to partial classes
- Fixed demo Sidebar