### PR TITLE
fix: Missing Switch track color for Material provider

### DIFF
--- a/Source/Blazorise.Material/Config.cs
+++ b/Source/Blazorise.Material/Config.cs
@@ -26,6 +26,11 @@ namespace Blazorise.Material
             return serviceCollection;
         }
 
+        private static void RegisterComponents( IComponentMapper componentMapper )
+        {
+            componentMapper.Replace( typeof( Blazorise.Switch<> ), typeof( Material.Switch<> ) );
+        }
+
         /// <summary>
         /// Registers the custom rules for material components.
         /// </summary>
@@ -35,6 +40,10 @@ namespace Blazorise.Material
         {
             // same components as in bootstrap provider
             serviceProvider.UseBootstrapProviders();
+
+            var componentMapper = serviceProvider.GetRequiredService<IComponentMapper>();
+
+            RegisterComponents( componentMapper );
 
             return serviceProvider;
         }

--- a/Source/Blazorise.Material/MaterialThemeGenerator.cs
+++ b/Source/Blazorise.Material/MaterialThemeGenerator.cs
@@ -49,6 +49,16 @@ namespace Blazorise.Material
                 .Append( $".custom-switch .custom-control-input:checked ~ .custom-control-label::after" ).Append( "{" )
                 .Append( $"background-color: {options.CheckColor};" )
                 .AppendLine( "}" );
+
+            var trackColor = ToHex( Lighten( options.CheckColor, 50f ) );
+
+            if ( !string.IsNullOrEmpty( trackColor ) )
+            {
+                sb
+                    .Append( $".custom-switch .custom-control-input:checked~.custom-control-track" ).Append( "{" )
+                    .Append( $"background-color: {trackColor};" )
+                    .AppendLine( "}" );
+            }
         }
     }
 }

--- a/Source/Blazorise.Material/Switch.razor
+++ b/Source/Blazorise.Material/Switch.razor
@@ -1,0 +1,8 @@
+﻿@typeparam TValue
+@inherits Blazorise.Switch<TValue>
+<Control Role="@ControlRole.Switch" Inline="@Inline">
+    <input @ref="@ElementRef" id="@ElementId" type="checkbox" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" checked="@Checked" @onchange="@OnChangeHandler" @attributes="@Attributes" />
+    <span class="custom-control-track"></span>
+    <Label Type="LabelType.Switch" For="@ElementId" Style="@Style" Cursor="@Cursor">@ChildContent</Label>
+    @Feedback
+</Control>

--- a/Source/Blazorise/ComponentMapper.cs
+++ b/Source/Blazorise/ComponentMapper.cs
@@ -60,6 +60,14 @@ namespace Blazorise
             }
         }
 
+        public void Replace( Type component, Type implementation )
+        {
+            if ( components.ContainsKey( component ) )
+            {
+                components[component] = implementation;
+            }
+        }
+
         public bool HasRegistration<TComponent>()
             where TComponent : IComponent
         {

--- a/Source/Blazorise/IComponentMapper.cs
+++ b/Source/Blazorise/IComponentMapper.cs
@@ -45,6 +45,13 @@ namespace Blazorise
         void Register( Type component, Type implementation );
 
         /// <summary>
+        /// Replaces already registered components with new custom implementation.
+        /// </summary>
+        /// <param name="component">Base component type.</param>
+        /// <param name="implementation">Implementation component type.</param>
+        void Replace( Type component, Type implementation );
+
+        /// <summary>
         /// Checks if a component type has a custom registration.
         /// </summary>
         /// <typeparam name="TComponent">Component type to check.</typeparam>

--- a/Source/Blazorise/ThemeGenerator.cs
+++ b/Source/Blazorise/ThemeGenerator.cs
@@ -514,14 +514,21 @@ namespace Blazorise
             return $"#{color.R.ToString( "X2" )}{color.G.ToString( "X2" )}{color.B.ToString( "X2" )}{color.A.ToString( "X2" )}";
         }
 
+        protected static System.Drawing.Color Transparency( string hexColor, int A )
+        {
+            var color = ParseColor( hexColor );
+
+            return System.Drawing.Color.FromArgb( A, color.R, color.G, color.B );
+        }
+
         protected static System.Drawing.Color Transparency( System.Drawing.Color color, int A )
         {
             return System.Drawing.Color.FromArgb( A, color.R, color.G, color.B );
         }
 
-        protected static System.Drawing.Color Darken( string inColor, float correctionFactor )
+        protected static System.Drawing.Color Darken( string hexColor, float correctionFactor )
         {
-            var color = ParseColor( inColor );
+            var color = ParseColor( hexColor );
 
             return ChangeColorBrightness( color, -( correctionFactor / 100f ) );
         }
@@ -531,9 +538,9 @@ namespace Blazorise
             return ChangeColorBrightness( color, -( correctionFactor / 100f ) );
         }
 
-        protected static System.Drawing.Color Lighten( string inColor, float correctionFactor )
+        protected static System.Drawing.Color Lighten( string hexColor, float correctionFactor )
         {
-            var color = ParseColor( inColor );
+            var color = ParseColor( hexColor );
 
             return ChangeColorBrightness( color, correctionFactor / 100f );
         }


### PR DESCRIPTION
#799 Weird graphics for Switch in Material

Material Switch was missing `<span class="custom-control-track"></span>` from it's implementation.