### PR TITLE
fix: Make Ant Design collapse header clickable

### DIFF
--- a/Source/Blazorise.AntDesign/CollapseHeader.razor
+++ b/Source/Blazorise.AntDesign/CollapseHeader.razor
@@ -1,0 +1,12 @@
+﻿@inherits Blazorise.CollapseHeader
+<div class="@ClassNames" style="@StyleNames" @attributes="@Attributes" @onclick="@ClickHandler">
+    <span role="img" aria-label="right" class="anticon anticon-right ant-collapse-arrow">
+        <svg viewBox="64 64 896 896" focusable="false" class="" data-icon="right" width="1em" height="1em" fill="currentColor" aria-hidden="true" style="@IconStlyes"><path d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"></path></svg>
+    </span>
+    @ChildContent
+</div>
+
+@code {
+    string IconStlyes 
+        => ParentCollapse.Visible ? "transform: rotate(90deg);" : "";
+}

--- a/Source/Blazorise.AntDesign/Config.cs
+++ b/Source/Blazorise.AntDesign/Config.cs
@@ -56,6 +56,7 @@ namespace Blazorise.AntDesign
             componentMapper.Register<Blazorise.CardHeader, AntDesign.CardHeader>();
             componentMapper.Register<Blazorise.CardLink, AntDesign.CardLink>();
             componentMapper.Register<Blazorise.CloseButton, AntDesign.CloseButton>();
+            componentMapper.Register<Blazorise.CollapseHeader, AntDesign.CollapseHeader>();
             componentMapper.Register<Blazorise.Dropdown, AntDesign.Dropdown>();
             componentMapper.Register<Blazorise.DropdownMenu, AntDesign.DropdownMenu>();
             componentMapper.Register<Blazorise.DropdownItem, AntDesign.DropdownItem>();

--- a/Source/Blazorise/Collapse.razor
+++ b/Source/Blazorise/Collapse.razor
@@ -3,7 +3,7 @@
 {
     <CascadingValue Value=this>
         <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-            <CascadingValue Value="@Visible" Name="Collapse">
+            <CascadingValue Value="@Visible" Name="CollapseVisible">
                 @ChildContent
             </CascadingValue>
         </div>

--- a/Source/Blazorise/Collapse.razor
+++ b/Source/Blazorise/Collapse.razor
@@ -1,11 +1,13 @@
 ﻿@inherits BaseComponent
 @if ( !HasCustomRegistration )
 {
-    <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-        <CascadingValue Value="@Visible" Name="Collapse">
-            @ChildContent
-        </CascadingValue>
-    </div>
+    <CascadingValue Value=this>
+        <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+            <CascadingValue Value="@Visible" Name="Collapse">
+                @ChildContent
+            </CascadingValue>
+        </div>
+    </CascadingValue>
 }
 else
 {

--- a/Source/Blazorise/Collapse.razor.cs
+++ b/Source/Blazorise/Collapse.razor.cs
@@ -18,18 +18,18 @@ namespace Blazorise
 
         #region Methods
 
-        public void Toggle()
-        {
-            Visible = !Visible;
-            StateHasChanged();
-        }
-
         protected override void BuildClasses( ClassBuilder builder )
         {
             builder.Append( ClassProvider.Collapse() );
             builder.Append( ClassProvider.CollapseActive( Visible ) );
 
             base.BuildClasses( builder );
+        }
+
+        public void Toggle()
+        {
+            Visible = !Visible;
+            StateHasChanged();
         }
 
         #endregion

--- a/Source/Blazorise/Collapse.razor.cs
+++ b/Source/Blazorise/Collapse.razor.cs
@@ -18,6 +18,12 @@ namespace Blazorise
 
         #region Methods
 
+        public void Toggle()
+        {
+            Visible = !Visible;
+            StateHasChanged();
+        }
+
         protected override void BuildClasses( ClassBuilder builder )
         {
             builder.Append( ClassProvider.Collapse() );

--- a/Source/Blazorise/CollapseBody.razor.cs
+++ b/Source/Blazorise/CollapseBody.razor.cs
@@ -61,7 +61,7 @@ namespace Blazorise
         /// <summary>
         /// Gets or sets the content visibility.
         /// </summary>
-        [CascadingParameter( Name = "Collapse" )]
+        [CascadingParameter( Name = "CollapseVisible" )]
         public bool Visible
         {
             get => visible;

--- a/Source/Blazorise/CollapseHeader.razor.cs
+++ b/Source/Blazorise/CollapseHeader.razor.cs
@@ -23,9 +23,16 @@ namespace Blazorise
             base.BuildClasses( builder );
         }
 
+        protected void ClickHandler()
+        {
+            ParentCollapse.Toggle();
+        }
+
         #endregion
 
         #region Properties
+
+        [CascadingParameter] protected Collapse ParentCollapse { get; set; }
 
         [Parameter] public RenderFragment ChildContent { get; set; }
 


### PR DESCRIPTION
In Ant Design, the `Header` of the `Collapse` is clickable ([for reference](https://ant.design/components/collapse/#components-collapse-demo-basic)).

So I have made some changes to allow the Ant Design `Header` to be clickable in Blazorise.

Addresses #820 