### PR TITLE
fix: Autocomplete dropdown menu not showing AntDesign

### DIFF
--- a/Source/Blazorise.AntDesign/Styles/_dropdown.scss
+++ b/Source/Blazorise.AntDesign/Styles/_dropdown.scss
@@ -20,3 +20,7 @@
         border-bottom-left-radius: 0;
     }
 }
+
+.ant-dropdown-group.ant-dropdown-button.b-is-autocomplete {
+    width: 100%;
+}

--- a/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
+++ b/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
@@ -260,6 +260,9 @@
     border-top-left-radius: 0;
     border-bottom-left-radius: 0; }
 
+.ant-dropdown-group.ant-dropdown-button.b-is-autocomplete {
+    width: 100%; }
+
 .ant-list.ant-list-bordered.ant-list-flush {
     border-right: 0;
     border-left: 0; }

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor
@@ -1,5 +1,5 @@
 ﻿@typeparam TItem
-<Dropdown @ref="dropdownRef" Class="@Class" Style="@Style" Attributes="@Attributes">
+<Dropdown @ref="dropdownRef" Class="@DropdownClassNames" Style="@Style" Attributes="@Attributes" Visible="@DropdownVisible">
     <TextEdit Text="@SelectedText" TextChanged="@HandleTextChanged" Placeholder="@Placeholder" Size="@Size" Disabled="@Disabled" KeyDown="@HandleTextKeyDown" />
     <DropdownMenu>
         @if ( DropdownVisible )

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -176,6 +176,9 @@ namespace Blazorise.Components
 
         protected bool DropdownVisible => Data != null && TextField != null && CurrentSearch?.Length >= MinLength;
 
+        protected string DropdownClassNames
+            => $"{Class} b-is-autocomplete";
+
         /// <summary>
         /// Defines the method by which the search will be done.
         /// </summary>


### PR DESCRIPTION
#824 Autocomplete not working in AntDesign

- Fixed Dropdown menu visibility
- Fixed input width within dropodown