### PR TITLE
fix: Switch cursor not working

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Tests/FormsPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/FormsPage.razor
@@ -444,7 +444,7 @@
                     </Field>
                 </Fields>
                 <Field>
-                    <Switch TValue="bool">Remember me</Switch>
+                    <Switch TValue="bool" Cursor="Cursor.Pointer">Remember me</Switch>
                 </Field>
                 <Field>
                     <Button Color="Color.Primary">Sign in</Button>

--- a/Source/Blazorise.Bootstrap/Styles/_form.scss
+++ b/Source/Blazorise.Bootstrap/Styles/_form.scss
@@ -1,6 +1,8 @@
 ﻿.form-check > .form-check-input.form-check-input-pointer,
 .form-check > .form-check-label.form-check-label-pointer,
 .custom-checkbox > .custom-control-input.custom-control-input-pointer,
-.custom-checkbox > .custom-control-label.custom-control-label-pointer {
+.custom-checkbox > .custom-control-label.custom-control-label-pointer,
+.custom-switch > .custom-control-input.custom-control-input-pointer,
+.custom-switch > .custom-control-label.custom-control-label-pointer {
     cursor: pointer;
 }

--- a/Source/Blazorise.Bootstrap/wwwroot/blazorise.bootstrap.css
+++ b/Source/Blazorise.Bootstrap/wwwroot/blazorise.bootstrap.css
@@ -62,7 +62,9 @@
 .form-check > .form-check-input.form-check-input-pointer,
 .form-check > .form-check-label.form-check-label-pointer,
 .custom-checkbox > .custom-control-input.custom-control-input-pointer,
-.custom-checkbox > .custom-control-label.custom-control-label-pointer {
+.custom-checkbox > .custom-control-label.custom-control-label-pointer,
+.custom-switch > .custom-control-input.custom-control-input-pointer,
+.custom-switch > .custom-control-label.custom-control-label-pointer {
     cursor: pointer; }
 
 .jumbotron.jumbotron-primary {


### PR DESCRIPTION
#664 Switch Component Cursor Property doesn't work

Fixed switch cursor for bootstrap provider