### PR TITLE
fix: remove empty cell for detail row

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/_DataGridDetailRow.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridDetailRow.razor
@@ -1,21 +1,7 @@
 ﻿@typeparam TItem
 @inherits _BaseDataGridDetailRow<TItem>
 <TableRow style="background-color: unset;">
-    @{
-        var location = CommandColumnLocation;
-
-        if ( location == "start" && ParentDataGrid.Editable )
-        {
-            <TableRowCell>
-            </TableRowCell>
-        }
-        <TableRowCell ColumnSpan="@Columns.Count">
-            @ChildContent
-        </TableRowCell>
-        if ( location == "end" && ParentDataGrid.Editable )
-        {
-            <TableRowCell>
-            </TableRowCell>
-        }
-    }
+    <TableRowCell ColumnSpan="@ColumnSpan">
+        @ChildContent
+    </TableRowCell>
 </TableRow>

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridDetailRow.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridDetailRow.razor.cs
@@ -20,23 +20,11 @@ namespace Blazorise.DataGrid
 
         #region Properties
 
-        protected bool HasCommandColumn => Columns.Any( x => x.ColumnType == DataGridColumnType.Command );
+        protected bool HasCommandColumn
+            => Columns.Any( x => x.ColumnType == DataGridColumnType.Command );
 
-        protected string CommandColumnLocation
-        {
-            get
-            {
-                if ( Columns.Count > 1 && HasCommandColumn )
-                {
-                    if ( Columns[0].ColumnType == DataGridColumnType.Command )
-                        return "start";
-                    else if ( Columns[Columns.Count - 1].ColumnType == DataGridColumnType.Command )
-                        return "end";
-                }
-
-                return string.Empty;
-            }
-        }
+        protected int ColumnSpan
+            => Columns.Count - ( HasCommandColumn && ParentDataGrid.Editable ? 0 : 1 );
 
         /// <summary>
         /// Item associated with the data set.


### PR DESCRIPTION
#447 DetailRowTemplate - Remove empty td or change size
#622 [DataGrid] [Material] Issue with DetailRowTemplate in Editable DataGrid

Removed an empty table cells for detail row making it to fill entire row.