### PR TITLE
feat: validation summary

### DIFF
--- a/Source/Blazorise.AntDesign/AntDesignClassProvider.cs
+++ b/Source/Blazorise.AntDesign/AntDesignClassProvider.cs
@@ -152,6 +152,10 @@ namespace Blazorise.AntDesign
 
         public override string ValidationNone() => "ant-form-item-explain";
 
+        public override string ValidationSummary() => "ant-typography-danger";
+
+        public override string ValidationSummaryError() => "ant-typography-danger";
+
         #endregion
 
         #region Fields

--- a/Source/Blazorise.Bootstrap/BootstrapClassProvider.cs
+++ b/Source/Blazorise.Bootstrap/BootstrapClassProvider.cs
@@ -166,6 +166,10 @@ namespace Blazorise.Bootstrap
 
         public override string ValidationNone() => "form-text text-muted";
 
+        public override string ValidationSummary() => "text-danger";
+
+        public override string ValidationSummaryError() => "text-danger";
+
         #endregion
 
         #region Fields

--- a/Source/Blazorise.Bulma/BulmaClassProvider.cs
+++ b/Source/Blazorise.Bulma/BulmaClassProvider.cs
@@ -166,6 +166,10 @@ namespace Blazorise.Bulma
 
         public override string ValidationNone() => "help";
 
+        public override string ValidationSummary() => "has-text-danger";
+
+        public override string ValidationSummaryError() => "has-text-danger";
+
         #endregion
 
         #endregion

--- a/Source/Blazorise.Frolic/FrolicClassProvider.cs
+++ b/Source/Blazorise.Frolic/FrolicClassProvider.cs
@@ -165,6 +165,10 @@ namespace Blazorise.Frolic
 
         public override string ValidationNone() => "e-form-info text-muted";
 
+        public override string ValidationSummary() => "text-danger";
+
+        public override string ValidationSummaryError() => "text-danger";
+
         #endregion
 
         #region Fields

--- a/Source/Blazorise/BaseValidationResult.cs
+++ b/Source/Blazorise/BaseValidationResult.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazorise
 {
-    public abstract class BaseValidationSummary : BaseComponent
+    public abstract class BaseValidationResult : BaseComponent
     {
         #region Members
 
@@ -20,7 +20,7 @@ namespace Blazorise
 
         #region Methods
 
-        public BaseValidationSummary()
+        public BaseValidationResult()
         {
             validationStatusChangedHandler += ( sender, eventArgs ) =>
             {

--- a/Source/Blazorise/ClassProvider.cs
+++ b/Source/Blazorise/ClassProvider.cs
@@ -152,6 +152,10 @@ namespace Blazorise
 
         public abstract string ValidationNone();
 
+        public abstract string ValidationSummary();
+
+        public abstract string ValidationSummaryError();
+
         #endregion
 
         #region Fields

--- a/Source/Blazorise/EventArguments.cs
+++ b/Source/Blazorise/EventArguments.cs
@@ -57,47 +57,24 @@ namespace Blazorise
         public string ErrorText { get; set; }
     }
 
-    public class ValidationSucceededEventArgs : EventArgs
+    public class FailedValidationsEventArgs : EventArgs
     {
-    }
-
-    public class ValidationFailedEventArgs : EventArgs
-    {
-        public ValidationFailedEventArgs( string errorText )
+        public FailedValidationsEventArgs( IReadOnlyList<string> errorMessages )
         {
-            ErrorText = errorText;
+            ErrorMessages = errorMessages;
         }
 
         /// <summary>
-        /// Gets the custom validation error message.
+        /// Gets the list of all error messages.
         /// </summary>
-        public string ErrorText { get; }
+        public IReadOnlyList<string> ErrorMessages { get; }
     }
 
-    public class ValidatedEventArgs : EventArgs
+    public class ClearedValidationsEventArgs : EventArgs
     {
-        public ValidatedEventArgs( ValidationStatus status, string errorText )
-        {
-            Status = status;
-            ErrorText = errorText;
-        }
+        public static new readonly ClearedValidationsEventArgs Empty = new ClearedValidationsEventArgs();
 
-        /// <summary>
-        /// Gets the validation result.
-        /// </summary>
-        public ValidationStatus Status { get; set; }
-
-        /// <summary>
-        /// Gets the custom validation error message.
-        /// </summary>
-        public string ErrorText { get; }
-    }
-
-    public class ValidationStartedEventArgs : EventArgs
-    {
-        public static new readonly ValidationStartedEventArgs Empty = new ValidationStartedEventArgs();
-
-        public ValidationStartedEventArgs()
+        public ClearedValidationsEventArgs()
         {
         }
     }
@@ -121,6 +98,27 @@ namespace Blazorise
         /// Gets the custom validation message.
         /// </summary>
         public string Message { get; }
+    }
+
+    public class ValidationsStatusChangedEventArgs : EventArgs
+    {
+        public static new readonly ValidationsStatusChangedEventArgs Empty = new ValidationsStatusChangedEventArgs( ValidationStatus.None, null );
+
+        public ValidationsStatusChangedEventArgs( ValidationStatus status, IReadOnlyCollection<string> messages )
+        {
+            Status = status;
+            Messages = messages;
+        }
+
+        /// <summary>
+        /// Gets the validation result.
+        /// </summary>
+        public ValidationStatus Status { get; set; }
+
+        /// <summary>
+        /// Gets the custom validation message.
+        /// </summary>
+        public IReadOnlyCollection<string> Messages { get; }
     }
 
     /// <summary>

--- a/Source/Blazorise/EventHandlers.cs
+++ b/Source/Blazorise/EventHandlers.cs
@@ -8,17 +8,11 @@ using System.Threading.Tasks;
 
 namespace Blazorise
 {
-    public delegate void ValidateEventHandler( ValidatorEventArgs e );
-
-    public delegate void ValidationFailedEventHandler( ValidationFailedEventArgs e );
-
-    public delegate void ValidationSucceededEventHandler( ValidationSucceededEventArgs e );
-
-    public delegate void ValidatingEventHandler();
+    public delegate void ValidationStartedEventHandler();
 
     public delegate void ValidatingAllEventHandler( ValidatingAllEventArgs e );
 
-    public delegate void ValidatedEventHandler( ValidatedEventArgs e );
+    public delegate void ClearAllValidationsEventHandler();
 
-    public delegate void ClearAllValidatinaEventHandler();
+    public delegate void ValidationsStatusChangedEventHandler( ValidationsStatusChangedEventArgs e );
 }

--- a/Source/Blazorise/IClassProvider.cs
+++ b/Source/Blazorise/IClassProvider.cs
@@ -151,6 +151,10 @@ namespace Blazorise
 
         string ValidationNone();
 
+        string ValidationSummary();
+
+        string ValidationSummaryError();
+
         #endregion
 
         #region Fields

--- a/Source/Blazorise/IValidation.cs
+++ b/Source/Blazorise/IValidation.cs
@@ -15,5 +15,10 @@ namespace Blazorise
         /// Gets the last validation status.
         /// </summary>
         ValidationStatus Status { get; }
+
+        /// <summary>
+        /// Gets the last error message.
+        /// </summary>
+        string LastErrorMessage { get; }
     }
 }

--- a/Source/Blazorise/Providers/EmptyClassProvider.cs
+++ b/Source/Blazorise/Providers/EmptyClassProvider.cs
@@ -155,6 +155,10 @@ namespace Blazorise.Providers
 
         public string ValidationNone() => null;
 
+        public string ValidationSummary() => null;
+
+        public string ValidationSummaryError() => null;
+
         #endregion
 
         #region Fields

--- a/Source/Blazorise/RadioGroup.razor
+++ b/Source/Blazorise/RadioGroup.razor
@@ -2,11 +2,11 @@
 @inherits BaseInputComponent<TValue>
 @if ( !HasCustomRegistration )
 {
-    <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-        <CascadingValue Value=this>
+    <CascadingValue Value=this>
+        <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
             @ChildContent
-        </CascadingValue>
-    </div>
+        </div>
+    </CascadingValue>
 }
 else
 {

--- a/Source/Blazorise/Validation.razor.cs
+++ b/Source/Blazorise/Validation.razor.cs
@@ -50,7 +50,7 @@ namespace Blazorise
         /// <summary>
         /// Raises an event that the validation has started.
         /// </summary>
-        public event ValidatingEventHandler Validating;
+        public event ValidationStartedEventHandler ValidationStarted;
 
         /// <summary>
         /// Raises every time a validation state has changed.
@@ -174,7 +174,7 @@ namespace Blazorise
             }
             else if ( EditContext != null && hasFieldIdentifier )
             {
-                Validating?.Invoke();
+                ValidationStarted?.Invoke();
 
                 var messages = new ValidationMessageStore( EditContext );
 
@@ -191,7 +191,7 @@ namespace Blazorise
 
                 if ( validatorHandler != null )
                 {
-                    Validating?.Invoke();
+                    ValidationStarted?.Invoke();
 
                     var validatorEventArgs = new ValidatorEventArgs( inputComponent.ValidationValue );
 
@@ -223,7 +223,7 @@ namespace Blazorise
         {
             ValidationStatusChanged?.Invoke( this, new ValidationStatusChangedEventArgs( status, message ) );
 
-            ParentValidations?.NotifyValidationStatusChanged();
+            ParentValidations?.NotifyValidationStatusChanged( this );
         }
 
         #endregion

--- a/Source/Blazorise/ValidationError.razor
+++ b/Source/Blazorise/ValidationError.razor
@@ -1,4 +1,4 @@
-﻿@inherits BaseValidationSummary
+﻿@inherits BaseValidationResult
 @if ( !HasCustomRegistration )
 {
     @if ( ParentValidation?.Status == ValidationStatus.Error )

--- a/Source/Blazorise/ValidationError.razor.cs
+++ b/Source/Blazorise/ValidationError.razor.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazorise
 {
-    public partial class ValidationError : BaseValidationSummary
+    public partial class ValidationError : BaseValidationResult
     {
         #region Members
 

--- a/Source/Blazorise/ValidationNone.razor
+++ b/Source/Blazorise/ValidationNone.razor
@@ -1,4 +1,4 @@
-﻿@inherits BaseValidationSummary
+﻿@inherits BaseValidationResult
 @if ( !HasCustomRegistration )
 {
     @if ( ParentValidation?.Status == ValidationStatus.None )

--- a/Source/Blazorise/ValidationNone.razor.cs
+++ b/Source/Blazorise/ValidationNone.razor.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazorise
 {
-    public partial class ValidationNone : BaseValidationSummary
+    public partial class ValidationNone : BaseValidationResult
     {
         #region Members
 

--- a/Source/Blazorise/ValidationSuccess.razor
+++ b/Source/Blazorise/ValidationSuccess.razor
@@ -1,4 +1,4 @@
-﻿@inherits BaseValidationSummary
+﻿@inherits BaseValidationResult
 @if ( !HasCustomRegistration )
 {
     @if ( ParentValidation?.Status == ValidationStatus.Success )

--- a/Source/Blazorise/ValidationSuccess.razor.cs
+++ b/Source/Blazorise/ValidationSuccess.razor.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazorise
 {
-    public partial class ValidationSuccess : BaseValidationSummary
+    public partial class ValidationSuccess : BaseValidationResult
     {
         #region Members
 

--- a/Source/Blazorise/ValidationSummary.razor
+++ b/Source/Blazorise/ValidationSummary.razor
@@ -1,0 +1,20 @@
+﻿@inherits BaseComponent
+@if ( !HasCustomRegistration )
+{
+    <ul class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+        @if ( HasErrorMessages )
+        {
+            @Label
+        }
+
+        @foreach ( var errorMessage in ErrorMessages )
+        {
+            <li class="@ErrorClassNames">@errorMessage</li>
+        }
+        @ChildContent
+    </ul>
+}
+else
+{
+    @RenderCustomComponent()
+}

--- a/Source/Blazorise/ValidationSummary.razor.cs
+++ b/Source/Blazorise/ValidationSummary.razor.cs
@@ -1,0 +1,118 @@
+﻿#region Using directives
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.Extensions.Primitives;
+#endregion
+
+namespace Blazorise
+{
+    public partial class ValidationSummary : BaseComponent
+    {
+        #region Members
+
+        private Validations previousParentValidations;
+
+        private readonly ValidationsStatusChangedEventHandler validationsStatusChangedEventHandler;
+
+        private IReadOnlyCollection<string> errorMessages;
+
+        #endregion
+
+        #region Constructors
+
+        public ValidationSummary()
+        {
+            ErrorClassBuilder = new ClassBuilder( BuildErrorClasses );
+
+            validationsStatusChangedEventHandler += ( eventArgs ) =>
+            {
+                OnValidationsStatusChanged( eventArgs );
+                StateHasChanged();
+            };
+        }
+
+        #endregion
+
+        #region Methods
+
+        protected override void BuildClasses( ClassBuilder builder )
+        {
+            builder.Append( ClassProvider.ValidationSummary() );
+
+            base.BuildClasses( builder );
+        }
+
+        private void BuildErrorClasses( ClassBuilder builder )
+        {
+            builder.Append( ClassProvider.ValidationSummaryError() );
+        }
+
+        protected override void Dispose( bool disposing )
+        {
+            if ( disposing )
+            {
+                DetachAllListener();
+            }
+
+            base.Dispose( disposing );
+        }
+
+        protected override void OnParametersSet()
+        {
+            if ( ParentValidations != previousParentValidations )
+            {
+                DetachAllListener();
+
+                ParentValidations.StatusChanged += validationsStatusChangedEventHandler;
+
+                previousParentValidations = ParentValidations;
+            }
+        }
+
+        private void DetachAllListener()
+        {
+            if ( previousParentValidations != null )
+            {
+                previousParentValidations.StatusChanged -= validationsStatusChangedEventHandler;
+            }
+        }
+
+        private void OnValidationsStatusChanged( ValidationsStatusChangedEventArgs eventArgs )
+        {
+            errorMessages = eventArgs.Messages;
+        }
+
+        #endregion
+
+        #region Properties
+
+        protected ClassBuilder ErrorClassBuilder { get; private set; }
+
+        protected string ErrorClassNames => ErrorClassBuilder.Class;
+
+        protected bool HasErrorMessages
+            => errorMessages?.Count > 0;
+
+        /// <summary>
+        /// Gets the list of error messages.
+        /// </summary>
+        protected IReadOnlyCollection<string> ErrorMessages
+            => errorMessages ?? Enumerable.Empty<string>().ToList();
+
+        /// <summary>
+        /// Label showed before the error messages.
+        /// </summary>
+        [Parameter] public string Label { get; set; }
+
+        [CascadingParameter] protected Validations ParentValidations { get; set; }
+
+        [Parameter] public RenderFragment ChildContent { get; set; }
+
+        #endregion
+    }
+}

--- a/Source/Blazorise/ValidationSummary.razor.cs
+++ b/Source/Blazorise/ValidationSummary.razor.cs
@@ -68,7 +68,7 @@ namespace Blazorise
             {
                 DetachAllListener();
 
-                ParentValidations.StatusChanged += validationsStatusChangedEventHandler;
+                ParentValidations._StatusChanged += validationsStatusChangedEventHandler;
 
                 previousParentValidations = ParentValidations;
             }
@@ -78,7 +78,7 @@ namespace Blazorise
         {
             if ( previousParentValidations != null )
             {
-                previousParentValidations.StatusChanged -= validationsStatusChangedEventHandler;
+                previousParentValidations._StatusChanged -= validationsStatusChangedEventHandler;
             }
         }
 

--- a/Source/Blazorise/Validations.razor.cs
+++ b/Source/Blazorise/Validations.razor.cs
@@ -22,7 +22,12 @@ namespace Blazorise
         /// </summary>
         public event ValidatingAllEventHandler ValidatingAll;
 
-        public event ClearAllValidatinaEventHandler ClearingAll;
+        public event ClearAllValidationsEventHandler ClearingAll;
+
+        /// <summary>
+        /// Event is fired whenever there is a change in validation status.
+        /// </summary>
+        public event ValidationsStatusChangedEventHandler StatusChanged;
 
         /// <summary>
         /// List of validations placed inside of this container.
@@ -52,7 +57,13 @@ namespace Blazorise
 
             if ( result )
             {
+                RaiseStatusChanged( ValidationStatus.Success, null );
+
                 ValidatedAll.InvokeAsync( null );
+            }
+            else if ( HasFailedValidations )
+            {
+                RaiseStatusChanged( ValidationStatus.Error, FailedValidations );
             }
 
             return result;
@@ -64,6 +75,8 @@ namespace Blazorise
         public void ClearAll()
         {
             ClearingAll?.Invoke();
+
+            RaiseStatusChanged( ValidationStatus.None, null );
         }
 
         private bool TryValidateAll()
@@ -98,15 +111,35 @@ namespace Blazorise
             }
         }
 
-        internal void NotifyValidationStatusChanged()
+        internal void NotifyValidationStatusChanged( IValidation validation )
         {
+            // Here we need to call ValidatedAll only when in Auto mode. Manuall call is already called through ValidateAll()
             if ( Mode == ValidationMode.Manual )
                 return;
 
-            if ( validations.All( x => x.Status == ValidationStatus.Success ) )
+            // NOTE: there is risk of calling RaiseStatusChanged multiple times for every field error.
+            // Try to come up with solution that StatusChanged will be called only once while it will
+            // still provide all of the failed messages.
+
+            if ( AllValidationsSuccessful )
             {
+                RaiseStatusChanged( ValidationStatus.Success, null );
+
                 ValidatedAll.InvokeAsync( null );
             }
+            else if ( HasFailedValidations )
+            {
+                RaiseStatusChanged( ValidationStatus.Error, FailedValidations );
+            }
+            else
+            {
+                RaiseStatusChanged( ValidationStatus.None, null );
+            }
+        }
+
+        private void RaiseStatusChanged( ValidationStatus status, IReadOnlyCollection<string> messages )
+        {
+            StatusChanged?.Invoke( new ValidationsStatusChangedEventArgs( status, messages ) );
         }
 
         #endregion
@@ -125,9 +158,41 @@ namespace Blazorise
         /// </summary>
         [Parameter] public object Model { get; set; }
 
+        /// <summary>
+        /// Message that will be displayed if any of the validations does not have defined error message.
+        /// </summary>
+        [Parameter] public string MissingFieldsErrorMessage { get; set; }
+
+        /// <summary>
+        /// Event is fired only after all of the validation are successful.
+        /// </summary>
         [Parameter] public EventCallback ValidatedAll { get; set; }
 
         [Parameter] public RenderFragment ChildContent { get; set; }
+
+        private bool AllValidationsSuccessful
+            => validations.All( x => x.Status == ValidationStatus.Success );
+
+        private bool HasFailedValidations
+            => validations.Any( x => x.Status == ValidationStatus.Error );
+
+        private IReadOnlyCollection<string> FailedValidations
+        {
+            get
+            {
+                return validations
+                    .Where( x => x.Status == ValidationStatus.Error && !string.IsNullOrWhiteSpace( x.LastErrorMessage ) )
+                    .Select( x => x.LastErrorMessage )
+                    .Concat(
+                        // In case there are some fields that do not have error message we need to combine them all under one message.
+                        validations.Any( v => v.Status == ValidationStatus.Error
+                            && string.IsNullOrWhiteSpace( v.LastErrorMessage )
+                            && !validations.Where( v2 => v2.Status == ValidationStatus.Error && !string.IsNullOrWhiteSpace( v2.LastErrorMessage ) ).Contains( v ) )
+                        ? new string[] { MissingFieldsErrorMessage ?? "One or more fields have an error. Please check and try again." }
+                        : new string[] { } )
+                    .ToList();
+            }
+        }
 
         #endregion
     }

--- a/Source/Blazorise/Validations.razor.cs
+++ b/Source/Blazorise/Validations.razor.cs
@@ -27,7 +27,7 @@ namespace Blazorise
         /// <summary>
         /// Event is fired whenever there is a change in validation status.
         /// </summary>
-        public event ValidationsStatusChangedEventHandler StatusChanged;
+        internal event ValidationsStatusChangedEventHandler _StatusChanged;
 
         /// <summary>
         /// List of validations placed inside of this container.
@@ -139,7 +139,9 @@ namespace Blazorise
 
         private void RaiseStatusChanged( ValidationStatus status, IReadOnlyCollection<string> messages )
         {
-            StatusChanged?.Invoke( new ValidationsStatusChangedEventArgs( status, messages ) );
+            _StatusChanged?.Invoke( new ValidationsStatusChangedEventArgs( status, messages ) );
+
+            StatusChanged.InvokeAsync( new ValidationsStatusChangedEventArgs( status, messages ) );
         }
 
         #endregion
@@ -167,6 +169,11 @@ namespace Blazorise
         /// Event is fired only after all of the validation are successful.
         /// </summary>
         [Parameter] public EventCallback ValidatedAll { get; set; }
+
+        /// <summary>
+        /// Event is fired whenever there is a change in validation status.
+        /// </summary>
+        [Parameter] public EventCallback<ValidationsStatusChangedEventArgs> StatusChanged { get; set; }
 
         [Parameter] public RenderFragment ChildContent { get; set; }
 

--- a/docs/_docs/components/validation.md
+++ b/docs/_docs/components/validation.md
@@ -14,6 +14,7 @@ Validation component is used to provide simple form validation for Blazorise inp
       - `<ValidationSuccess>` success message
       - `<ValidationError>` error message
       - `<ValidationNone>` message when nothing has happened
+  - `ValidationSummary` lists all error messages
 
 **Notice:** Starting from **v0.9** it is advised to also surround `Field` components with `Validation` tags. This will ensure that validation will work in all scenarios!
 {: .notice--warning}
@@ -205,6 +206,18 @@ public class User
 **Note:** For a full source code you can look at the [validation page](https://github.com/stsrki/Blazorise/blob/master/Tests/Blazorise.Demo/Pages/Tests/ValidationsPage.razor) inside of a demo application.
 {: .notice--info}
 
+## Validation summary
+
+Sometimes you don't want to show error messages under each field. In those situations you can use `ValidationSummary` component. Once placed inside of `Validations` it will show all error messages as a bullet list.
+
+```html
+<Validations @ref="annotationsValidations" Mode="ValidationMode.Manual" Model="@manualUser">
+    <ValidationSummary Label="Following error occurs..." />
+
+    // other validation fields
+</Validations>
+```
+
 ## Validation rules
 
 In Blazorise you can use some of the predefined validation rules. eg
@@ -227,6 +240,18 @@ Here is a list of the validators currently available.
 | IsLowercase                  | Check if the string is lowercase.                                  |
 
 ## Attributes
+
+### Validations
+
+| Name                      | Type                                                                              | Default  | Description                                                                                            |
+|---------------------------|-----------------------------------------------------------------------------------|----------|--------------------------------------------------------------------------------------------------------|
+| Mode                      | [ValidationMode]({{ "/docs/helpers/enums/#validationmode" | relative_url }})      | `Auto`   | Defines the validation mode for validations inside of this container.                                  |
+| Model                     | object                                                                            | null     | Specifies the top-level model object for the form. An edit context will be constructed for this model. |
+| MissingFieldsErrorMessage | string                                                                            |          | Message that will be displayed if any of the validations does not have defined error message.          |
+| ValidatedAll              | EventCallback                                                                     |          | Event is fired only after all of the validation are successful.                                        |
+| StatusChanged             | event                                                                             |          | Event is fired whenever there is a change in validation status.                                        |
+
+## Validation
 
 | Name         | Type                                                                              | Default  | Description                                                                                |
 |--------------|-----------------------------------------------------------------------------------|----------|--------------------------------------------------------------------------------------------|

--- a/docs/_docs/components/validation.md
+++ b/docs/_docs/components/validation.md
@@ -249,9 +249,9 @@ Here is a list of the validators currently available.
 | Model                     | object                                                                            | null     | Specifies the top-level model object for the form. An edit context will be constructed for this model. |
 | MissingFieldsErrorMessage | string                                                                            |          | Message that will be displayed if any of the validations does not have defined error message.          |
 | ValidatedAll              | EventCallback                                                                     |          | Event is fired only after all of the validation are successful.                                        |
-| StatusChanged             | event                                                                             |          | Event is fired whenever there is a change in validation status.                                        |
+| StatusChanged             | EventCallback                                                                     |          | Event is fired whenever there is a change in validation status.                                        |
 
-## Validation
+### Validation
 
 | Name         | Type                                                                              | Default  | Description                                                                                |
 |--------------|-----------------------------------------------------------------------------------|----------|--------------------------------------------------------------------------------------------|

--- a/docs/_docs/helpers/enums.md
+++ b/docs/_docs/helpers/enums.md
@@ -223,3 +223,10 @@ Defines the breadcrumb activation mode.
 - `None` Default behavior.
 - `Left` Show the snackbar on the left side of the screen.
 - `Right` Show the snackbar on the right side of the screen.
+
+## ValidationMode
+
+Defines the validation execution mode.
+
+- `Auto` Validation will execute on every input change.
+- `Manual` Validation will run only when explicitly called.


### PR DESCRIPTION
This PR covers two tickets: #658 and #851 

Changes include:
- new `ValidationSummary` component that acts as a placeholder for listing all error messages
- new `StatusChanged` event callback that is used to notify of latest validation status
- renamed BaseValidationSummary into BaseValidationResult
- removed unused delegates from EventHandlers.cs
- updated validation page in documentation