### PR TITLE
fix: bulma datagrid pagination links not active

### DIFF
--- a/Source/Blazorise.Bulma/BulmaClassProvider.cs
+++ b/Source/Blazorise.Bulma/BulmaClassProvider.cs
@@ -680,7 +680,7 @@ namespace Blazorise.Bulma
 
         public override string PaginationLinkActive() => "is-current";
 
-        public override string PaginationLinkDisabled() => "disabled";
+        public override string PaginationLinkDisabled() => "is-disabled";
 
         #endregion
 

--- a/Source/Blazorise/PaginationItem.razor
+++ b/Source/Blazorise/PaginationItem.razor
@@ -2,9 +2,11 @@
 @if ( !HasCustomRegistration )
 {
     <CascadingValue Value=this>
-        <li class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-            @ChildContent
-        </li>
+        <CascadingValue Value="@Active" Name="PaginationItemActive">
+            <li class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+                @ChildContent
+            </li>
+        </CascadingValue>
     </CascadingValue>
 }
 else

--- a/Source/Blazorise/PaginationItem.razor.cs
+++ b/Source/Blazorise/PaginationItem.razor.cs
@@ -24,7 +24,7 @@ namespace Blazorise
         {
             builder.Append( ClassProvider.PaginationItem() );
             builder.Append( ClassProvider.PaginationItemActive(), Active );
-            builder.Append( ClassProvider.Disabled(), Disabled );
+            builder.Append( ClassProvider.PaginationItemDisabled(), Disabled );
 
             base.BuildClasses( builder );
         }

--- a/Source/Blazorise/PaginationLink.razor.cs
+++ b/Source/Blazorise/PaginationLink.razor.cs
@@ -13,6 +13,8 @@ namespace Blazorise
     {
         #region Members
 
+        private bool active;
+
         #endregion
 
         #region Methods
@@ -20,7 +22,7 @@ namespace Blazorise
         protected override void BuildClasses( ClassBuilder builder )
         {
             builder.Append( ClassProvider.PaginationLink() );
-            builder.Append( ClassProvider.PaginationLinkActive(), ParentPaginationItem?.Active == true );
+            builder.Append( ClassProvider.PaginationLinkActive(), Active );
 
             base.BuildClasses( builder );
         }
@@ -37,8 +39,7 @@ namespace Blazorise
         /// <summary>
         /// Gets or sets the page name.
         /// </summary>
-        [Parameter]
-        public string Page { get; set; }
+        [Parameter] public string Page { get; set; }
 
         /// <summary>
         /// Occurs when the item link is clicked.
@@ -47,7 +48,17 @@ namespace Blazorise
 
         [Parameter] public RenderFragment ChildContent { get; set; }
 
-        [CascadingParameter] protected PaginationItem ParentPaginationItem { get; set; }
+        [CascadingParameter( Name = "PaginationItemActive" )]
+        protected bool Active
+        {
+            get => active;
+            set
+            {
+                active = value;
+
+                DirtyClasses();
+            }
+        }
 
         #endregion
     }


### PR DESCRIPTION
#669 

Active state from PaginationItem was cascaded to PaginationLink but it was missing a call to DirtyClass().