### PR TITLE
Cascading stores instead of separate properties

### DIFF
--- a/Source/Blazorise.AntDesign/Dropdown.razor
+++ b/Source/Blazorise.AntDesign/Dropdown.razor
@@ -1,6 +1,8 @@
 ﻿@inherits Blazorise.Dropdown
 <CascadingValue Value=this>
-    <div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-        @ChildContent
-    </div>
+    <CascadingValue Value="@Store">
+        <div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+            @ChildContent
+        </div>
+    </CascadingValue>
 </CascadingValue>

--- a/Source/Blazorise.AntDesign/Tabs.razor
+++ b/Source/Blazorise.AntDesign/Tabs.razor
@@ -1,27 +1,29 @@
 ﻿@inherits Blazorise.Tabs
 <CascadingValue Value=this>
-    <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-        <div role="tablist" class="@TabsBarClassNames">
-            <div class="ant-tabs-nav-container">
-                <div class="ant-tabs-nav-wrap">
-                    <div class="ant-tabs-nav-scroll">
-                        <div class="ant-tabs-nav ant-tabs-nav-animated">
-                            <div>
-                                @if ( Items != null )
-                                {
-                                    @Items
-                                }
+    <CascadingValue Value="@Store">
+        <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+            <div role="tablist" class="@TabsBarClassNames">
+                <div class="ant-tabs-nav-container">
+                    <div class="ant-tabs-nav-wrap">
+                        <div class="ant-tabs-nav-scroll">
+                            <div class="ant-tabs-nav ant-tabs-nav-animated">
+                                <div>
+                                    @if ( Items != null )
+                                    {
+                                        @Items
+                                    }
+                                </div>
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
+            @if ( Content != null )
+            {
+                <div class="@($"{ContentClassNames} {ContentPositionClassNames}")" @attributes="@Attributes" style="@StyleOfSelectedTab">
+                    @Content
+                </div>
+            }
         </div>
-        @if ( Content != null )
-        {
-            <div class="@($"{ContentClassNames} {ContentPositionClassNames}")" @attributes="@Attributes" style="@StyleOfSelectedTab">
-                @Content
-            </div>
-        }
-    </div>
+    </CascadingValue>
 </CascadingValue>

--- a/Source/Blazorise.AntDesign/TabsContent.razor
+++ b/Source/Blazorise.AntDesign/TabsContent.razor
@@ -1,6 +1,8 @@
 ﻿@inherits Blazorise.TabsContent
 <CascadingValue Value=this>
-    <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-        @ChildContent
-    </div>
+    <CascadingValue Value="@Store">
+        <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+            @ChildContent
+        </div>
+    </CascadingValue>
 </CascadingValue>

--- a/Source/Blazorise.Bulma/Tabs.razor
+++ b/Source/Blazorise.Bulma/Tabs.razor
@@ -1,66 +1,68 @@
 ﻿@inherits Blazorise.Tabs
 <CascadingValue Value=this>
-    @if ( TabPosition == TabPosition.Top )
-    {
-        @if ( Items != null )
+    <CascadingValue Value="@Store">
+        @if ( TabPosition == TabPosition.Top )
         {
-            <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-                <ul>
-                    @Items
-                </ul>
-            </div>
+            @if ( Items != null )
+            {
+                <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+                    <ul>
+                        @Items
+                    </ul>
+                </div>
+            }
+            @if ( Content != null )
+            {
+                <div class="@ContentClassNames" @attributes="@Attributes">
+                    @Content
+                </div>
+            }
         }
-        @if ( Content != null )
+        else if ( TabPosition == TabPosition.Left )
         {
-            <div class="@ContentClassNames" @attributes="@Attributes">
-                @Content
-            </div>
+            <Row>
+                <Column ColumnSize="ColumnSize.Is2">
+                    @if ( Items != null )
+                    {
+                        <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+                            <ul>
+                                @Items
+                            </ul>
+                        </div>
+                    }
+                </Column>
+                <Column ColumnSize="ColumnSize.Is10">
+                    @if ( Content != null )
+                    {
+                        <div class="@ContentClassNames" @attributes="@Attributes">
+                            @Content
+                        </div>
+                    }
+                </Column>
+            </Row>
         }
-    }
-    else if ( TabPosition == TabPosition.Left )
-    {
-        <Row>
-            <Column ColumnSize="ColumnSize.Is2">
-                @if ( Items != null )
-                {
-                    <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-                        <ul>
-                            @Items
-                        </ul>
-                    </div>
-                }
-            </Column>
-            <Column ColumnSize="ColumnSize.Is10">
-                @if ( Content != null )
-                {
-                    <div class="@ContentClassNames" @attributes="@Attributes">
-                        @Content
-                    </div>
-                }
-            </Column>
-        </Row>
-    }
-    else if ( TabPosition == TabPosition.Right )
-    {
-        <Row>
-            <Column ColumnSize="ColumnSize.Is10">
-                @if ( Content != null )
-                {
-                    <div class="@ContentClassNames" @attributes="@Attributes">
-                        @Content
-                    </div>
-                }
-            </Column>
-            <Column ColumnSize="ColumnSize.Is2">
-                @if ( Items != null )
-                {
-                    <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-                        <ul>
-                            @Items
-                        </ul>
-                    </div>
-                }
-            </Column>
-        </Row>
-    }
+        else if ( TabPosition == TabPosition.Right )
+        {
+            <Row>
+                <Column ColumnSize="ColumnSize.Is10">
+                    @if ( Content != null )
+                    {
+                        <div class="@ContentClassNames" @attributes="@Attributes">
+                            @Content
+                        </div>
+                    }
+                </Column>
+                <Column ColumnSize="ColumnSize.Is2">
+                    @if ( Items != null )
+                    {
+                        <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+                            <ul>
+                                @Items
+                            </ul>
+                        </div>
+                    }
+                </Column>
+            </Row>
+        }
+    </CascadingValue>
 </CascadingValue>

--- a/Source/Blazorise.Frolic/Dropdown.razor
+++ b/Source/Blazorise.Frolic/Dropdown.razor
@@ -1,8 +1,10 @@
 ﻿@inherits Blazorise.Dropdown
 <CascadingValue Value=this>
-    <div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-        @ChildContent
-    </div>
+    <CascadingValue Value="@Store">
+        <div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+            @ChildContent
+        </div>
+    </CascadingValue>
 </CascadingValue>
 @code{
     protected override void OnInitialized()

--- a/Source/Blazorise.Frolic/Tabs.razor
+++ b/Source/Blazorise.Frolic/Tabs.razor
@@ -1,66 +1,68 @@
 ﻿@inherits Blazorise.Tabs
 <CascadingValue Value=this>
-    @if ( TabPosition == TabPosition.Top )
-    {
-        @if ( Items != null )
+    <CascadingValue Value="@Store">
+        @if ( TabPosition == TabPosition.Top )
         {
-            <nav class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-                <ul>
-                    @Items
-                </ul>
-            </nav>
+            @if ( Items != null )
+            {
+                <nav class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+                    <ul>
+                        @Items
+                    </ul>
+                </nav>
+            }
+            @if ( Content != null )
+            {
+                <div class="@ContentClassNames" @attributes="@Attributes">
+                    @Content
+                </div>
+            }
         }
-        @if ( Content != null )
+        else if ( TabPosition == TabPosition.Left )
         {
-            <div class="@ContentClassNames" @attributes="@Attributes">
-                @Content
-            </div>
+            <Row>
+                <Column ColumnSize="ColumnSize.Is2">
+                    @if ( Items != null )
+                    {
+                        <nav class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+                            <ul>
+                                @Items
+                            </ul>
+                        </nav>
+                    }
+                </Column>
+                <Column>
+                    @if ( Content != null )
+                    {
+                        <div class="@ContentClassNames" @attributes="@Attributes">
+                            @Content
+                        </div>
+                    }
+                </Column>
+            </Row>
         }
-    }
-    else if ( TabPosition == TabPosition.Left )
-    {
-        <Row>
-            <Column ColumnSize="ColumnSize.Is2">
-                @if ( Items != null )
-                {
-                    <nav class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-                        <ul>
-                            @Items
-                        </ul>
-                    </nav>
-                }
-            </Column>
-            <Column>
-                @if ( Content != null )
-                {
-                    <div class="@ContentClassNames" @attributes="@Attributes">
-                        @Content
-                    </div>
-                }
-            </Column>
-        </Row>
-    }
-    else if ( TabPosition == TabPosition.Right )
-    {
-        <Row>
-            <Column>
-                @if ( Content != null )
-                {
-                    <div class="@ContentClassNames" @attributes="@Attributes">
-                        @Content
-                    </div>
-                }
-            </Column>
-            <Column ColumnSize="ColumnSize.Is2">
-                @if ( Items != null )
-                {
-                    <nav class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-                        <ul>
-                            @Items
-                        </ul>
-                    </nav>
-                }
-            </Column>
-        </Row>
-    }
+        else if ( TabPosition == TabPosition.Right )
+        {
+            <Row>
+                <Column>
+                    @if ( Content != null )
+                    {
+                        <div class="@ContentClassNames" @attributes="@Attributes">
+                            @Content
+                        </div>
+                    }
+                </Column>
+                <Column ColumnSize="ColumnSize.Is2">
+                    @if ( Items != null )
+                    {
+                        <nav class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+                            <ul>
+                                @Items
+                            </ul>
+                        </nav>
+                    }
+                </Column>
+            </Row>
+        }
+    </CascadingValue>
 </CascadingValue>

--- a/Source/Blazorise/Alert.razor
+++ b/Source/Blazorise/Alert.razor
@@ -2,9 +2,11 @@
 @if ( !HasCustomRegistration )
 {
     <CascadingValue Value=this>
-        <div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" role="alert" @attributes="@Attributes">
-            @ChildContent
-        </div>
+        <CascadingValue Value="@store">
+            <div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" role="alert" @attributes="@Attributes">
+                @ChildContent
+            </div>
+        </CascadingValue>
     </CascadingValue>
 }
 else

--- a/Source/Blazorise/Alert.razor.cs
+++ b/Source/Blazorise/Alert.razor.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Blazorise.Stores;
 using Microsoft.AspNetCore.Components;
 #endregion
 
@@ -12,13 +13,10 @@ namespace Blazorise
     {
         #region Members
 
-        private bool dismisable;
-
-        private bool visible;
-
-        private Color color = Color.None;
-
-        public event EventHandler<AlertStateEventArgs> StateChanged;
+        private AlertStore store = new AlertStore
+        {
+            Color = Color.None,
+        };
 
         private bool hasMessage;
 
@@ -80,6 +78,9 @@ namespace Blazorise
             Visibility = active ? Visibility.Always : Visibility.Never;
         }
 
+        /// <summary>
+        /// Notifies the alert that one of the child componens is a message.
+        /// </summary>
         internal void NotifyHasMessage()
         {
             hasMessage = true;
@@ -88,6 +89,9 @@ namespace Blazorise
             StateHasChanged();
         }
 
+        /// <summary>
+        /// Notifies the alert that one of the child componens is a description.
+        /// </summary>
         internal void NotifyHasDescription()
         {
             hasDescription = true;
@@ -106,10 +110,10 @@ namespace Blazorise
         [Parameter]
         public bool Dismisable
         {
-            get => dismisable;
+            get => store.Dismisable;
             set
             {
-                dismisable = value;
+                store.Dismisable = value;
 
                 DirtyClasses();
             }
@@ -121,18 +125,12 @@ namespace Blazorise
         [Parameter]
         public bool Visible
         {
-            get => visible;
+            get => store.Visible;
             set
             {
-                // prevent alert from calling the same code multiple times
-                if ( value == visible )
-                    return;
-
-                visible = value;
+                store.Visible = value;
 
                 HandleVisibilityState( value );
-
-                StateChanged?.Invoke( this, new AlertStateEventArgs( visible ) );
 
                 DirtyClasses();
             }
@@ -144,10 +142,10 @@ namespace Blazorise
         [Parameter]
         public Color Color
         {
-            get => color;
+            get => store.Color;
             set
             {
-                color = value;
+                store.Color = value;
 
                 DirtyClasses();
             }

--- a/Source/Blazorise/Dropdown.razor
+++ b/Source/Blazorise/Dropdown.razor
@@ -2,9 +2,11 @@
 @if ( !HasCustomRegistration )
 {
     <CascadingValue Value=this>
-        <div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-            @ChildContent
-        </div>
+        <CascadingValue Value="@store">
+            <div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+                @ChildContent
+            </div>
+        </CascadingValue>
     </CascadingValue>
 }
 else

--- a/Source/Blazorise/Dropdown.razor.cs
+++ b/Source/Blazorise/Dropdown.razor.cs
@@ -127,10 +127,6 @@ namespace Blazorise
             get => store.Visible;
             set
             {
-                // prevent dropdown from calling the same code multiple times
-                if ( value == store.Visible )
-                    return;
-
                 store.Visible = value;
 
                 DirtyClasses();

--- a/Source/Blazorise/Dropdown.razor.cs
+++ b/Source/Blazorise/Dropdown.razor.cs
@@ -18,8 +18,6 @@ namespace Blazorise
             Direction = Direction.Down,
         };
 
-        public event EventHandler<DropdownStateEventArgs> StateChanged;
-
         private List<Button> registeredButtons;
 
         #endregion
@@ -134,8 +132,6 @@ namespace Blazorise
                     return;
 
                 store.Visible = value;
-
-                StateChanged?.Invoke( this, new DropdownStateEventArgs( store.Visible ) );
 
                 DirtyClasses();
             }

--- a/Source/Blazorise/Dropdown.razor.cs
+++ b/Source/Blazorise/Dropdown.razor.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Blazorise.Stores;
 using Microsoft.AspNetCore.Components;
 #endregion
 
@@ -12,11 +13,10 @@ namespace Blazorise
     {
         #region Members
 
-        private bool visible;
-
-        private bool rightAligned;
-
-        private Direction direction = Direction.Down;
+        private DropdownStore store = new DropdownStore
+        {
+            Direction = Direction.Down,
+        };
 
         public event EventHandler<DropdownStateEventArgs> StateChanged;
 
@@ -113,6 +113,8 @@ namespace Blazorise
 
         #region Properties
 
+        protected DropdownStore Store => store;
+
         /// <summary>
         /// Makes the drop down to behave as a group for buttons(used for the split-button behaviour).
         /// </summary>
@@ -124,16 +126,16 @@ namespace Blazorise
         [Parameter]
         public bool Visible
         {
-            get => visible;
+            get => store.Visible;
             set
             {
                 // prevent dropdown from calling the same code multiple times
-                if ( value == visible )
+                if ( value == store.Visible )
                     return;
 
-                visible = value;
+                store.Visible = value;
 
-                StateChanged?.Invoke( this, new DropdownStateEventArgs( visible ) );
+                StateChanged?.Invoke( this, new DropdownStateEventArgs( store.Visible ) );
 
                 DirtyClasses();
             }
@@ -145,10 +147,10 @@ namespace Blazorise
         [Parameter]
         public bool RightAligned
         {
-            get => rightAligned;
+            get => store.RightAligned;
             set
             {
-                rightAligned = value;
+                store.RightAligned = value;
 
                 DirtyClasses();
             }
@@ -160,10 +162,10 @@ namespace Blazorise
         [Parameter]
         public Direction Direction
         {
-            get => direction;
+            get => store.Direction;
             set
             {
-                direction = value;
+                store.Direction = value;
 
                 DirtyClasses();
             }

--- a/Source/Blazorise/DropdownMenu.razor.cs
+++ b/Source/Blazorise/DropdownMenu.razor.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Blazorise.Stores;
 using Microsoft.AspNetCore.Components;
 #endregion
 
@@ -12,9 +13,7 @@ namespace Blazorise
     {
         #region Members
 
-        private bool visible;
-
-        private bool rightAligned;
+        private DropdownStore parentDropdownStore;
 
         #endregion
 
@@ -23,71 +22,26 @@ namespace Blazorise
         protected override void BuildClasses( ClassBuilder builder )
         {
             builder.Append( ClassProvider.DropdownMenu() );
-            builder.Append( ClassProvider.DropdownMenuVisible( Visible ) );
-            builder.Append( ClassProvider.DropdownMenuRight(), RightAligned );
+            builder.Append( ClassProvider.DropdownMenuVisible( ParentDropdownStore.Visible ) );
+            builder.Append( ClassProvider.DropdownMenuRight(), ParentDropdownStore.RightAligned );
 
             base.BuildClasses( builder );
-        }
-
-        protected override void OnInitialized()
-        {
-            if ( ParentDropdown != null )
-            {
-                Visible = ParentDropdown.Visible;
-
-                ParentDropdown.StateChanged += OnDropdownStateChanged;
-            }
-
-            base.OnInitialized();
-        }
-
-        protected override void Dispose( bool disposing )
-        {
-            if ( disposing )
-            {
-                if ( ParentDropdown != null )
-                {
-                    ParentDropdown.StateChanged -= OnDropdownStateChanged;
-                }
-            }
-
-            base.Dispose( disposing );
-        }
-
-        private void OnDropdownStateChanged( object sender, DropdownStateEventArgs e )
-        {
-            Visible = e.Visible;
         }
 
         #endregion
 
         #region Properties
 
-        /// <summary>
-        /// Handles the visibility of dropdown menu.
-        /// </summary>
-        [Parameter]
-        public bool Visible
+        [CascadingParameter]
+        protected DropdownStore ParentDropdownStore
         {
-            get => visible;
+            get => parentDropdownStore;
             set
             {
-                visible = value;
+                if ( parentDropdownStore == value )
+                    return;
 
-                DirtyClasses();
-            }
-        }
-
-        /// <summary>
-        /// Right aligned dropdown menu.
-        /// </summary>
-        [Parameter]
-        public bool RightAligned
-        {
-            get => rightAligned;
-            set
-            {
-                rightAligned = value;
+                parentDropdownStore = value;
 
                 DirtyClasses();
             }

--- a/Source/Blazorise/DropdownToggle.razor.cs
+++ b/Source/Blazorise/DropdownToggle.razor.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Blazorise.Stores;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 #endregion
@@ -13,29 +14,17 @@ namespace Blazorise
     {
         #region Members
 
-        private bool visible;
-
         private bool split;
 
         private bool jsRegistered;
 
         private DotNetObjectReference<CloseActivatorAdapter> dotNetObjectRef;
 
+        private DropdownStore parentDropdownStore;
+
         #endregion
 
         #region Methods
-
-        protected override void OnInitialized()
-        {
-            if ( ParentDropdown != null )
-            {
-                Visible = ParentDropdown.Visible;
-
-                ParentDropdown.StateChanged += OnDropdownStateChanged;
-            }
-
-            base.OnInitialized();
-        }
 
         protected override async Task OnFirstAfterRenderAsync()
         {
@@ -90,11 +79,6 @@ namespace Blazorise
             return Task.CompletedTask;
         }
 
-        private void OnDropdownStateChanged( object sender, DropdownStateEventArgs e )
-        {
-            Visible = e.Visible;
-        }
-
         /// <summary>
         /// Sets focus on the input element, if it can be focused.
         /// </summary>
@@ -121,34 +105,6 @@ namespace Blazorise
         [Parameter] public ButtonSize Size { get; set; } = ButtonSize.None;
 
         /// <summary>
-        /// Handles the visibility of dropdown toggle.
-        /// </summary>
-        [Parameter]
-        public bool Visible
-        {
-            get => visible;
-            set
-            {
-                visible = value;
-
-                if ( visible )
-                {
-                    jsRegistered = true;
-
-                    JSRunner.RegisterClosableComponent( dotNetObjectRef, ElementId );
-                }
-                else
-                {
-                    jsRegistered = false;
-
-                    JSRunner.UnregisterClosableComponent( this );
-                }
-
-                DirtyClasses();
-            }
-        }
-
-        /// <summary>
         /// Button outline.
         /// </summary>
         [Parameter] public bool Outline { get; set; }
@@ -163,6 +119,34 @@ namespace Blazorise
             set
             {
                 split = value;
+
+                DirtyClasses();
+            }
+        }
+
+        [CascadingParameter]
+        protected DropdownStore ParentDropdownStore
+        {
+            get => parentDropdownStore;
+            set
+            {
+                if ( parentDropdownStore == value )
+                    return;
+
+                parentDropdownStore = value;
+
+                if ( parentDropdownStore.Visible )
+                {
+                    jsRegistered = true;
+
+                    JSRunner.RegisterClosableComponent( dotNetObjectRef, ElementId );
+                }
+                else
+                {
+                    jsRegistered = false;
+
+                    JSRunner.UnregisterClosableComponent( this );
+                }
 
                 DirtyClasses();
             }

--- a/Source/Blazorise/EventArguments.cs
+++ b/Source/Blazorise/EventArguments.cs
@@ -206,38 +206,6 @@ namespace Blazorise
     }
 
     /// <summary>
-    /// Supplies the information about the selected tab.
-    /// </summary>
-    public class TabsStateEventArgs : EventArgs
-    {
-        public TabsStateEventArgs( string tabName )
-        {
-            TabName = tabName;
-        }
-
-        /// <summary>
-        /// Gets the selected tab name.
-        /// </summary>
-        public string TabName { get; }
-    }
-
-    /// <summary>
-    /// Supplies the information about the selected panel.
-    /// </summary>
-    public class TabsContentStateEventArgs : EventArgs
-    {
-        public TabsContentStateEventArgs( string panelName )
-        {
-            PanelName = panelName;
-        }
-
-        /// <summary>
-        /// Gets the selected panel name.
-        /// </summary>
-        public string PanelName { get; }
-    }
-
-    /// <summary>
     /// Supplies the information about the selected files ready to be uploaded.
     /// </summary>
     public class FileChangedEventArgs : EventArgs

--- a/Source/Blazorise/EventArguments.cs
+++ b/Source/Blazorise/EventArguments.cs
@@ -206,22 +206,6 @@ namespace Blazorise
     }
 
     /// <summary>
-    /// Supplies the information about the dropdown state.
-    /// </summary>
-    public class DropdownStateEventArgs : EventArgs
-    {
-        public DropdownStateEventArgs( bool visible )
-        {
-            Visible = visible;
-        }
-
-        /// <summary>
-        /// Gets that flag that indicates if the dropdown is opened.
-        /// </summary>
-        public bool Visible { get; }
-    }
-
-    /// <summary>
     /// Supplies the information about the bar-dropdown state.
     /// </summary>
     public class BarDropdownStateEventArgs : EventArgs

--- a/Source/Blazorise/EventArguments.cs
+++ b/Source/Blazorise/EventArguments.cs
@@ -174,22 +174,6 @@ namespace Blazorise
     }
 
     /// <summary>
-    /// Supplies the information about the modal visiblity state.
-    /// </summary>
-    public class ModalStateEventArgs : EventArgs
-    {
-        public ModalStateEventArgs( bool visible )
-        {
-            Visible = visible;
-        }
-
-        /// <summary>
-        /// Gets that flag that indicates if the modal is opened.
-        /// </summary>
-        public bool Visible { get; }
-    }
-
-    /// <summary>
     /// Supplies the information about the bar-dropdown state.
     /// </summary>
     public class BarDropdownStateEventArgs : EventArgs

--- a/Source/Blazorise/EventArguments.cs
+++ b/Source/Blazorise/EventArguments.cs
@@ -190,22 +190,6 @@ namespace Blazorise
     }
 
     /// <summary>
-    /// Supplies the information about the alert visiblity state.
-    /// </summary>
-    public class AlertStateEventArgs : EventArgs
-    {
-        public AlertStateEventArgs( bool visible )
-        {
-            Visible = visible;
-        }
-
-        /// <summary>
-        /// Gets that flag that indicates if the alert is visible.
-        /// </summary>
-        public bool Visible { get; }
-    }
-
-    /// <summary>
     /// Supplies the information about the bar-dropdown state.
     /// </summary>
     public class BarDropdownStateEventArgs : EventArgs

--- a/Source/Blazorise/Modal.razor
+++ b/Source/Blazorise/Modal.razor
@@ -2,9 +2,11 @@
 @if ( !HasCustomRegistration )
 {
     <CascadingValue Value=this>
-        <div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" tabindex="-1" role="dialog" @attributes="@Attributes">
-            @ChildContent
-        </div>
+        <CascadingValue Value="@store">
+            <div @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames" tabindex="-1" role="dialog" @attributes="@Attributes">
+                @ChildContent
+            </div>
+        </CascadingValue>
     </CascadingValue>
 }
 else

--- a/Source/Blazorise/Modal.razor.cs
+++ b/Source/Blazorise/Modal.razor.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
+using Blazorise.Stores;
 using Microsoft.AspNetCore.Components;
 #endregion
 
@@ -16,20 +17,15 @@ namespace Blazorise
     {
         #region Members
 
-        /// <summary>
-        /// Flag that indicates if modal is visible.
-        /// </summary>
-        private bool visible;
+        ModalStore store = new ModalStore
+        {
+            Visible = false,
+        };
 
         /// <summary>
         /// Holds the last received reason for modal closure.
         /// </summary>
         private CloseReason closeReason = CloseReason.None;
-
-        /// <summary>
-        /// Occurs when the <see cref="Visible"/> property value changes.
-        /// </summary>
-        public event EventHandler<ModalStateEventArgs> StateChanged;
 
         #endregion
 
@@ -81,7 +77,7 @@ namespace Blazorise
 
             if ( IsSafeToClose() )
             {
-                visible = false;
+                store.Visible = false;
 
                 HandleVisibilityStyles( false );
                 RaiseEvents( false );
@@ -140,8 +136,6 @@ namespace Blazorise
 
         private void RaiseEvents( bool visible )
         {
-            StateChanged?.Invoke( this, new ModalStateEventArgs( visible ) );
-
             if ( !visible )
             {
                 Closed.InvokeAsync( null );
@@ -158,23 +152,23 @@ namespace Blazorise
         [Parameter]
         public bool Visible
         {
-            get => visible;
+            get => store.Visible;
             set
             {
                 // prevent modal from calling the same code multiple times
-                if ( value == visible )
+                if ( value == store.Visible )
                     return;
 
                 if ( value == true )
                 {
-                    visible = true;
+                    store.Visible = true;
 
                     HandleVisibilityStyles( true );
                     RaiseEvents( true );
                 }
                 else if ( value == false && IsSafeToClose() )
                 {
-                    visible = false;
+                    store.Visible = false;
 
                     HandleVisibilityStyles( false );
                     RaiseEvents( false );

--- a/Source/Blazorise/ModalBackdrop.razor.cs
+++ b/Source/Blazorise/ModalBackdrop.razor.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Blazorise.Stores;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 #endregion
@@ -13,28 +14,15 @@ namespace Blazorise
     {
         #region Members
 
-        private bool visible;
+        private ModalStore parentModalStore;
 
-        private bool isRegistered;
+        private bool jsRegistered;
 
         private DotNetObjectReference<CloseActivatorAdapter> dotNetObjectRef;
 
         #endregion
 
         #region Methods
-
-        protected override void OnInitialized()
-        {
-            if ( ParentModal != null )
-            {
-                // initialize backdrop in case that modal is already set to visible
-                Visible = ParentModal.Visible;
-
-                ParentModal.StateChanged += OnModalStateChanged;
-            }
-
-            base.OnInitialized();
-        }
 
         protected override async Task OnFirstAfterRenderAsync()
         {
@@ -47,15 +35,10 @@ namespace Blazorise
         {
             if ( disposing )
             {
-                if ( ParentModal != null )
-                {
-                    ParentModal.StateChanged -= OnModalStateChanged;
-                }
-
                 // make sure to unregister listener
-                if ( isRegistered )
+                if ( jsRegistered )
                 {
-                    isRegistered = false;
+                    jsRegistered = false;
 
                     _ = JSRunner.UnregisterClosableComponent( this );
                 }
@@ -70,7 +53,7 @@ namespace Blazorise
         {
             builder.Append( ClassProvider.ModalBackdrop() );
             builder.Append( ClassProvider.ModalBackdropFade() );
-            builder.Append( ClassProvider.ModalBackdropVisible( Visible ) );
+            builder.Append( ClassProvider.ModalBackdropVisible( parentModalStore.Visible ) );
 
             base.BuildClasses( builder );
         }
@@ -87,41 +70,30 @@ namespace Blazorise
             return Task.CompletedTask;
         }
 
-        private void OnModalStateChanged( object sender, ModalStateEventArgs e )
-        {
-            Visible = e.Visible;
-        }
-
         #endregion
 
         #region Properties
 
-        /// <summary>
-        /// Defines the visibility of modal backdrop.
-        /// </summary>
-        /// <remarks>
-        /// Use this only when backdrop is placed outside of modal.
-        /// </remarks>
-        [Parameter]
-        public bool Visible
+        [CascadingParameter]
+        protected ModalStore ParentModalStore
         {
-            get => visible;
+            get => parentModalStore;
             set
             {
-                if ( value == visible )
+                if ( parentModalStore == value )
                     return;
 
-                visible = value;
+                parentModalStore = value;
 
-                if ( visible )
+                if ( parentModalStore.Visible )
                 {
-                    isRegistered = true;
+                    jsRegistered = true;
 
                     ExecuteAfterRender( async () => await JSRunner.RegisterClosableComponent( dotNetObjectRef, ElementId ) );
                 }
                 else
                 {
-                    isRegistered = false;
+                    jsRegistered = false;
 
                     ExecuteAfterRender( async () => await JSRunner.UnregisterClosableComponent( this ) );
                 }

--- a/Source/Blazorise/PaginationItem.razor
+++ b/Source/Blazorise/PaginationItem.razor
@@ -1,12 +1,10 @@
 ﻿@inherits BaseComponent
 @if ( !HasCustomRegistration )
 {
-    <CascadingValue Value=this>
-        <CascadingValue Value="@Active" Name="PaginationItemActive">
-            <li class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-                @ChildContent
-            </li>
-        </CascadingValue>
+    <CascadingValue Value="@store" >
+        <li class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+            @ChildContent
+        </li>
     </CascadingValue>
 }
 else

--- a/Source/Blazorise/PaginationItem.razor.cs
+++ b/Source/Blazorise/PaginationItem.razor.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Blazorise.Stores;
 using Microsoft.AspNetCore.Components;
 #endregion
 
@@ -12,9 +13,7 @@ namespace Blazorise
     {
         #region Members
 
-        private bool active;
-
-        private bool disabled;
+        private PaginationItemStore store = new PaginationItemStore();
 
         #endregion
 
@@ -39,10 +38,10 @@ namespace Blazorise
         [Parameter]
         public bool Active
         {
-            get => active;
+            get => store.Active;
             set
             {
-                active = value;
+                store.Active = value;
 
                 DirtyClasses();
             }
@@ -54,10 +53,10 @@ namespace Blazorise
         [Parameter]
         public bool Disabled
         {
-            get => disabled;
+            get => store.Disabled;
             set
             {
-                disabled = value;
+                store.Disabled = value;
 
                 DirtyClasses();
             }

--- a/Source/Blazorise/PaginationLink.razor.cs
+++ b/Source/Blazorise/PaginationLink.razor.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Blazorise.Stores;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 #endregion
@@ -13,7 +14,7 @@ namespace Blazorise
     {
         #region Members
 
-        private bool active;
+        private PaginationItemStore paginationItemStore;
 
         #endregion
 
@@ -22,7 +23,7 @@ namespace Blazorise
         protected override void BuildClasses( ClassBuilder builder )
         {
             builder.Append( ClassProvider.PaginationLink() );
-            builder.Append( ClassProvider.PaginationLinkActive(), Active );
+            builder.Append( ClassProvider.PaginationLinkActive(), PaginationItemStore.Active );
 
             base.BuildClasses( builder );
         }
@@ -48,13 +49,16 @@ namespace Blazorise
 
         [Parameter] public RenderFragment ChildContent { get; set; }
 
-        [CascadingParameter( Name = "PaginationItemActive" )]
-        protected bool Active
+        [CascadingParameter]
+        protected PaginationItemStore PaginationItemStore
         {
-            get => active;
+            get => paginationItemStore;
             set
             {
-                active = value;
+                if ( paginationItemStore == value )
+                    return;
+
+                paginationItemStore = value;
 
                 DirtyClasses();
             }

--- a/Source/Blazorise/Stores/AlertStore.cs
+++ b/Source/Blazorise/Stores/AlertStore.cs
@@ -1,0 +1,60 @@
+﻿#region Using directives
+using System;
+using System.Collections.Generic;
+using System.Resources;
+using System.Text;
+#endregion
+
+namespace Blazorise.Stores
+{
+    public struct AlertStore : IEquatable<AlertStore>
+    {
+        #region Methods
+
+        public override bool Equals( object obj )
+            => obj is AlertStore store && Equals( store );
+
+        public bool Equals( AlertStore other )
+        {
+            return Dismisable == other.Dismisable
+                && Visible == other.Visible
+                && Color == other.Color;
+        }
+
+        public override int GetHashCode()
+        {
+            // Use a different bit for bool fields: bool.GetHashCode() will return 0 (false) or 1 (true). So we would
+            // end up having the same hash code for e.g. two instances where one has only noCache set and the other
+            // only noStore.
+            var result = Dismisable.GetHashCode()
+             ^ ( Visible.GetHashCode() << 1 ); // increase shift by one for every bool field
+
+            result = result
+               ^ ( Color.GetHashCode() ^ 1 ); // power of two for every other field(^1, ^2, ^4, ^8, ^16, ...)
+
+            return result;
+        }
+
+        public static bool operator ==( AlertStore lhs, AlertStore rhs )
+        {
+            return lhs.Equals( rhs );
+        }
+
+        public static bool operator !=( AlertStore lhs, AlertStore rhs )
+        {
+            return !lhs.Equals( rhs );
+        }
+
+        #endregion
+
+        #region Properties
+
+        public bool Dismisable { readonly get; set; }
+
+        public bool Visible { readonly get; set; }
+
+        public Color Color { readonly get; set; }
+
+        #endregion
+    }
+}

--- a/Source/Blazorise/Stores/DropdownStore.cs
+++ b/Source/Blazorise/Stores/DropdownStore.cs
@@ -1,0 +1,60 @@
+﻿#region Using directives
+using System;
+using System.Collections.Generic;
+using System.Resources;
+using System.Text;
+#endregion
+
+namespace Blazorise.Stores
+{
+    public struct DropdownStore : IEquatable<DropdownStore>
+    {
+        #region Methods
+
+        public override bool Equals( object obj )
+            => obj is DropdownStore store && Equals( store );
+
+        public bool Equals( DropdownStore other )
+        {
+            return Visible == other.Visible
+                && RightAligned == other.RightAligned
+                && Direction == other.Direction;
+        }
+
+        public override int GetHashCode()
+        {
+            // Use a different bit for bool fields: bool.GetHashCode() will return 0 (false) or 1 (true). So we would
+            // end up having the same hash code for e.g. two instances where one has only noCache set and the other
+            // only noStore.
+            var result = Visible.GetHashCode()
+             ^ ( RightAligned.GetHashCode() << 1 ); // increase shift by one for every bool field
+
+            result = result
+                ^ ( Direction.GetHashCode() ^ 1 ); // power of two for every other field(^1, ^2, ^4, ^8, ^16, ...)
+
+            return result;
+        }
+
+        public static bool operator ==( DropdownStore lhs, DropdownStore rhs )
+        {
+            return lhs.Equals( rhs );
+        }
+
+        public static bool operator !=( DropdownStore lhs, DropdownStore rhs )
+        {
+            return !lhs.Equals( rhs );
+        }
+
+        #endregion
+
+        #region Properties
+
+        public bool Visible { readonly get; set; }
+
+        public bool RightAligned { readonly get; set; }
+
+        public Direction Direction { readonly get; set; }
+
+        #endregion
+    }
+}

--- a/Source/Blazorise/Stores/ModalStore.cs
+++ b/Source/Blazorise/Stores/ModalStore.cs
@@ -1,0 +1,47 @@
+﻿#region Using directives
+using System;
+using System.Collections.Generic;
+using System.Resources;
+using System.Text;
+#endregion
+
+namespace Blazorise.Stores
+{
+    public struct ModalStore : IEquatable<ModalStore>
+    {
+        #region Methods
+
+        public override bool Equals( object obj )
+            => obj is ModalStore store && Equals( store );
+
+        public bool Equals( ModalStore other )
+        {
+            return Visible == other.Visible;
+        }
+
+        public override int GetHashCode()
+        {
+            var result = Visible.GetHashCode();
+
+            return result;
+        }
+
+        public static bool operator ==( ModalStore lhs, ModalStore rhs )
+        {
+            return lhs.Equals( rhs );
+        }
+
+        public static bool operator !=( ModalStore lhs, ModalStore rhs )
+        {
+            return !lhs.Equals( rhs );
+        }
+
+        #endregion
+
+        #region Properties
+
+        public bool Visible { readonly get; set; }
+
+        #endregion
+    }
+}

--- a/Source/Blazorise/Stores/PaginationItemStore.cs
+++ b/Source/Blazorise/Stores/PaginationItemStore.cs
@@ -1,0 +1,54 @@
+﻿#region Using directives
+using System;
+using System.Collections.Generic;
+using System.Resources;
+using System.Text;
+#endregion
+
+namespace Blazorise.Stores
+{
+    public struct PaginationItemStore : IEquatable<PaginationItemStore>
+    {
+        #region Methods
+
+        public override bool Equals( object obj )
+            => obj is PaginationItemStore store && Equals( store );
+
+        public bool Equals( PaginationItemStore other )
+        {
+            return Active == other.Active
+                && Disabled == other.Disabled;
+        }
+
+        public override int GetHashCode()
+        {
+            // Use a different bit for bool fields: bool.GetHashCode() will return 0 (false) or 1 (true). So we would
+            // end up having the same hash code for e.g. two instances where one has only noCache set and the other
+            // only noStore.
+            var result = Active.GetHashCode()
+             ^ ( Disabled.GetHashCode() << 1 ); // increase shift by one for every bool field
+
+            return result;
+        }
+
+        public static bool operator ==( PaginationItemStore lhs, PaginationItemStore rhs )
+        {
+            return lhs.Equals( rhs );
+        }
+
+        public static bool operator !=( PaginationItemStore lhs, PaginationItemStore rhs )
+        {
+            return !lhs.Equals( rhs );
+        }
+
+        #endregion
+
+        #region Properties
+
+        public bool Active { readonly get; set; }
+
+        public bool Disabled { readonly get; set; }
+
+        #endregion
+    }
+}

--- a/Source/Blazorise/Stores/TabsContentStore.cs
+++ b/Source/Blazorise/Stores/TabsContentStore.cs
@@ -1,0 +1,47 @@
+﻿#region Using directives
+using System;
+using System.Collections.Generic;
+using System.Resources;
+using System.Text;
+#endregion
+
+namespace Blazorise.Stores
+{
+    public struct TabsContentStore : IEquatable<TabsContentStore>
+    {
+        #region Methods
+
+        public override bool Equals( object obj )
+            => obj is TabsContentStore store && Equals( store );
+
+        public bool Equals( TabsContentStore other )
+        {
+            return SelectedPanel == other.SelectedPanel;
+        }
+
+        public override int GetHashCode()
+        {
+            var result = SelectedPanel.GetHashCode();
+
+            return result;
+        }
+
+        public static bool operator ==( TabsContentStore lhs, TabsContentStore rhs )
+        {
+            return lhs.Equals( rhs );
+        }
+
+        public static bool operator !=( TabsContentStore lhs, TabsContentStore rhs )
+        {
+            return !lhs.Equals( rhs );
+        }
+
+        #endregion
+
+        #region Properties
+
+        public string SelectedPanel { readonly get; set; }
+
+        #endregion
+    }
+}

--- a/Source/Blazorise/Stores/TabsStore.cs
+++ b/Source/Blazorise/Stores/TabsStore.cs
@@ -1,0 +1,70 @@
+﻿#region Using directives
+using System;
+using System.Collections.Generic;
+using System.Resources;
+using System.Text;
+#endregion
+
+namespace Blazorise.Stores
+{
+    public struct TabsStore : IEquatable<TabsStore>
+    {
+        #region Methods
+
+        public override bool Equals( object obj )
+            => obj is TabsStore store && Equals( store );
+
+        public bool Equals( TabsStore other )
+        {
+            return Pills == other.Pills
+                && FullWidth == other.FullWidth
+                && Justified == other.Justified
+                && TabPosition == other.TabPosition
+                && SelectedTab == other.SelectedTab;
+        }
+
+        public override int GetHashCode()
+        {
+            // Use a different bit for bool fields: bool.GetHashCode() will return 0 (false) or 1 (true). So we would
+            // end up having the same hash code for e.g. two instances where one has only noCache set and the other
+            // only noStore.
+            var result = Pills.GetHashCode()
+             ^ ( FullWidth.GetHashCode() << 1 )
+             ^ ( Justified.GetHashCode() << 2 ); // increase shift by one for every bool field
+
+            result = result
+                ^ ( TabPosition.GetHashCode() ^ 1 ); // power of two for every other field(^1, ^2, ^4, ^8, ^16, ...)
+
+            if ( SelectedTab != null )
+                result ^= SelectedTab.GetHashCode();
+
+            return result;
+        }
+
+        public static bool operator ==( TabsStore lhs, TabsStore rhs )
+        {
+            return lhs.Equals( rhs );
+        }
+
+        public static bool operator !=( TabsStore lhs, TabsStore rhs )
+        {
+            return !lhs.Equals( rhs );
+        }
+
+        #endregion
+
+        #region Properties
+
+        public bool Pills { readonly get; set; }
+
+        public bool FullWidth { readonly get; set; }
+
+        public bool Justified { readonly get; set; }
+
+        public TabPosition TabPosition { readonly get; set; }
+
+        public string SelectedTab { readonly get; set; }
+
+        #endregion
+    }
+}

--- a/Source/Blazorise/Tab.razor.cs
+++ b/Source/Blazorise/Tab.razor.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Blazorise.Stores;
 using Microsoft.AspNetCore.Components;
 #endregion
 
@@ -12,7 +13,7 @@ namespace Blazorise
     {
         #region Members
 
-        private bool active;
+        private TabsStore parentTabsStore;
 
         private bool disabled;
 
@@ -57,37 +58,15 @@ namespace Blazorise
             if ( ParentTabs != null )
             {
                 ParentTabs.HookTab( Name );
-
-                Active = Name == ParentTabs.SelectedTab;
-
-                ParentTabs.StateChanged += OnTabsStateChanged;
             }
 
             base.OnInitialized();
-        }
-
-        protected override void Dispose( bool disposing )
-        {
-            if ( disposing )
-            {
-                if ( ParentTabs != null )
-                {
-                    ParentTabs.StateChanged -= OnTabsStateChanged;
-                }
-            }
-
-            base.Dispose( disposing );
         }
 
         protected void ClickHandler()
         {
             Clicked?.Invoke();
             ParentTabs?.SelectTab( Name );
-        }
-
-        private void OnTabsStateChanged( object sender, TabsStateEventArgs e )
-        {
-            Active = Name == e.TabName;
         }
 
         #endregion
@@ -101,24 +80,12 @@ namespace Blazorise
         /// </summary>
         protected string LinkClassNames => LinkClassBuilder.Class;
 
+        protected bool Active => parentTabsStore.SelectedTab == Name;
+
         /// <summary>
         /// Defines the tab name. Must match the coresponding panel name.
         /// </summary>
         [Parameter] public string Name { get; set; }
-
-        /// <summary>
-        /// Determines is the tab active.
-        /// </summary>
-        public bool Active
-        {
-            get => active;
-            private set
-            {
-                active = value;
-
-                DirtyClasses();
-            }
-        }
 
         /// <summary>
         /// Determines is the tab is disabled.
@@ -139,6 +106,21 @@ namespace Blazorise
         /// Occurs when the item is clicked.
         /// </summary>
         [Parameter] public Action Clicked { get; set; }
+
+        [CascadingParameter]
+        protected TabsStore ParentTabsStore
+        {
+            get => parentTabsStore;
+            set
+            {
+                if ( parentTabsStore == value )
+                    return;
+
+                parentTabsStore = value;
+
+                DirtyClasses();
+            }
+        }
 
         [CascadingParameter] protected Tabs ParentTabs { get; set; }
 

--- a/Source/Blazorise/TabPanel.razor.cs
+++ b/Source/Blazorise/TabPanel.razor.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Blazorise.Stores;
 using Microsoft.AspNetCore.Components;
 #endregion
 
@@ -12,7 +13,9 @@ namespace Blazorise
     {
         #region Members
 
-        private bool active;
+        private TabsStore parentTabsStore;
+
+        private TabsContentStore parentTabsContentStore;
 
         #endregion
 
@@ -31,70 +34,52 @@ namespace Blazorise
             if ( ParentTabs != null )
             {
                 ParentTabs.HookPanel( Name );
-
-                Active = Name == ParentTabs.SelectedTab;
-
-                ParentTabs.StateChanged += OnTabsContentStateChanged;
             }
 
             if ( ParentTabsContent != null )
             {
                 ParentTabsContent.Hook( Name );
-
-                Active = Name == ParentTabsContent.SelectedPanel;
-
-                ParentTabsContent.StateChanged += OnTabsContentStateChanged;
             }
 
             base.OnInitialized();
-        }
-
-        protected override void Dispose( bool disposing )
-        {
-            if ( disposing )
-            {
-                if ( ParentTabs != null )
-                {
-                    ParentTabs.StateChanged -= OnTabsContentStateChanged;
-                }
-
-                if ( ParentTabsContent != null )
-                {
-                    ParentTabsContent.StateChanged -= OnTabsContentStateChanged;
-                }
-            }
-
-            base.Dispose( disposing );
-        }
-
-        private void OnTabsContentStateChanged( object sender, TabsStateEventArgs e )
-        {
-            Active = Name == e.TabName;
-        }
-
-        private void OnTabsContentStateChanged( object sender, TabsContentStateEventArgs e )
-        {
-            Active = Name == e.PanelName;
         }
 
         #endregion
 
         #region Properties
 
+        protected bool Active => parentTabsStore.SelectedTab == Name || parentTabsContentStore.SelectedPanel == Name;
+
         /// <summary>
         /// Defines the panel name. Must match the coresponding tab name.
         /// </summary>
         [Parameter] public string Name { get; set; }
 
-        /// <summary>
-        /// Determines is the panel active.
-        /// </summary>
-        public bool Active
+        [CascadingParameter]
+        protected TabsStore ParentTabsStore
         {
-            get => active;
-            private set
+            get => parentTabsStore;
+            set
             {
-                active = value;
+                if ( parentTabsStore == value )
+                    return;
+
+                parentTabsStore = value;
+
+                DirtyClasses();
+            }
+        }
+
+        [CascadingParameter]
+        protected TabsContentStore ParentTabsContentStore
+        {
+            get => parentTabsContentStore;
+            set
+            {
+                if ( parentTabsContentStore == value )
+                    return;
+
+                parentTabsContentStore = value;
 
                 DirtyClasses();
             }

--- a/Source/Blazorise/Tabs.razor
+++ b/Source/Blazorise/Tabs.razor
@@ -2,78 +2,80 @@
 @if ( !HasCustomRegistration )
 {
     <CascadingValue Value=this>
-        @if ( TabPosition == TabPosition.Top )
-        {
-            @if ( Items != null )
+        <CascadingValue Value="@store">
+            @if ( TabPosition == TabPosition.Top )
             {
-                <ul class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-                    @Items
-                </ul>
+                @if ( Items != null )
+                {
+                    <ul class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+                        @Items
+                    </ul>
+                }
+                @if ( Content != null )
+                {
+                    <div class="@ContentClassNames" @attributes="@Attributes">
+                        @Content
+                    </div>
+                }
             }
-            @if ( Content != null )
+            else if ( TabPosition == TabPosition.Bottom )
             {
-                <div class="@ContentClassNames" @attributes="@Attributes">
-                    @Content
-                </div>
+                @if ( Content != null )
+                {
+                    <div class="@ContentClassNames" @attributes="@Attributes">
+                        @Content
+                    </div>
+                }
+                @if ( Items != null )
+                {
+                    <ul class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+                        @Items
+                    </ul>
+                }
             }
-        }
-        else if ( TabPosition == TabPosition.Bottom )
-        {
-            @if ( Content != null )
+            else if ( TabPosition == TabPosition.Left )
             {
-                <div class="@ContentClassNames" @attributes="@Attributes">
-                    @Content
-                </div>
+                <Row>
+                    <Column ColumnSize="ColumnSize.IsAuto">
+                        @if ( Items != null )
+                        {
+                            <ul class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+                                @Items
+                            </ul>
+                        }
+                    </Column>
+                    <Column>
+                        @if ( Content != null )
+                        {
+                            <div class="@ContentClassNames" @attributes="@Attributes">
+                                @Content
+                            </div>
+                        }
+                    </Column>
+                </Row>
             }
-            @if ( Items != null )
+            else if ( TabPosition == TabPosition.Right )
             {
-                <ul class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-                    @Items
-                </ul>
+                <Row>
+                    <Column>
+                        @if ( Content != null )
+                        {
+                            <div class="@ContentClassNames" @attributes="@Attributes">
+                                @Content
+                            </div>
+                        }
+                    </Column>
+                    <Column ColumnSize="ColumnSize.IsAuto">
+                        @if ( Items != null )
+                        {
+                            <ul class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+                                @Items
+                            </ul>
+                        }
+                    </Column>
+                </Row>
             }
-        }
-        else if ( TabPosition == TabPosition.Left )
-        {
-            <Row>
-                <Column ColumnSize="ColumnSize.IsAuto">
-                    @if ( Items != null )
-                    {
-                        <ul class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-                            @Items
-                        </ul>
-                    }
-                </Column>
-                <Column>
-                    @if ( Content != null )
-                    {
-                        <div class="@ContentClassNames" @attributes="@Attributes">
-                            @Content
-                        </div>
-                    }
-                </Column>
-            </Row>
-        }
-        else if ( TabPosition == TabPosition.Right )
-        {
-            <Row>
-                <Column>
-                    @if ( Content != null )
-                    {
-                        <div class="@ContentClassNames" @attributes="@Attributes">
-                            @Content
-                        </div>
-                    }
-                </Column>
-                <Column ColumnSize="ColumnSize.IsAuto">
-                    @if ( Items != null )
-                    {
-                        <ul class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-                            @Items
-                        </ul>
-                    }
-                </Column>
-            </Row>
-        }
+        </CascadingValue>
     </CascadingValue>
 }
 else

--- a/Source/Blazorise/Tabs.razor.cs
+++ b/Source/Blazorise/Tabs.razor.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Blazorise.Stores;
 using Microsoft.AspNetCore.Components;
 #endregion
 
@@ -12,17 +13,10 @@ namespace Blazorise
     {
         #region Members
 
-        private bool pills;
-
-        private bool fullWidth;
-
-        private bool justified;
-
-        private string selectedTab;
-
-        private TabPosition tabPosition = TabPosition.Top;
-
-        public event EventHandler<TabsStateEventArgs> StateChanged;
+        private TabsStore store = new TabsStore
+        {
+            TabPosition = TabPosition.Top,
+        };
 
         private List<string> tabItems = new List<string>();
 
@@ -83,6 +77,8 @@ namespace Blazorise
 
         #region Properties
 
+        protected TabsStore Store => store;
+
         protected bool IsCards => CardHeader != null;
 
         protected ClassBuilder ContentClassBuilder { get; private set; }
@@ -92,7 +88,7 @@ namespace Blazorise
         /// </summary>
         protected string ContentClassNames => ContentClassBuilder.Class;
 
-        protected int IndexOfSelectedTab => tabItems.IndexOf( selectedTab );
+        protected int IndexOfSelectedTab => tabItems.IndexOf( store.SelectedTab );
 
         protected IReadOnlyList<string> TabItems => tabItems;
 
@@ -104,10 +100,10 @@ namespace Blazorise
         [Parameter]
         public bool Pills
         {
-            get => pills;
+            get => store.Pills;
             set
             {
-                pills = value;
+                store.Pills = value;
 
                 DirtyClasses();
             }
@@ -119,10 +115,10 @@ namespace Blazorise
         [Parameter]
         public bool FullWidth
         {
-            get => fullWidth;
+            get => store.FullWidth;
             set
             {
-                fullWidth = value;
+                store.FullWidth = value;
 
                 DirtyClasses();
             }
@@ -134,10 +130,10 @@ namespace Blazorise
         [Parameter]
         public bool Justified
         {
-            get => justified;
+            get => store.Justified;
             set
             {
-                justified = value;
+                store.Justified = value;
 
                 DirtyClasses();
             }
@@ -149,10 +145,10 @@ namespace Blazorise
         [Parameter]
         public TabPosition TabPosition
         {
-            get => tabPosition;
+            get => store.TabPosition;
             set
             {
-                tabPosition = value;
+                store.TabPosition = value;
 
                 DirtyClasses();
             }
@@ -164,18 +160,17 @@ namespace Blazorise
         [Parameter]
         public string SelectedTab
         {
-            get => selectedTab;
+            get => store.SelectedTab;
             set
             {
                 // prevent tabs from calling the same code multiple times
-                if ( value == selectedTab )
+                if ( value == store.SelectedTab )
                     return;
 
-                selectedTab = value;
+                store.SelectedTab = value;
 
-                // raise the tabchanged notification
-                StateChanged?.Invoke( this, new TabsStateEventArgs( selectedTab ) );
-                SelectedTabChanged.InvokeAsync( selectedTab );
+                // raise the tabchanged notification                
+                SelectedTabChanged.InvokeAsync( store.SelectedTab );
 
                 DirtyClasses();
             }

--- a/Source/Blazorise/TabsContent.razor
+++ b/Source/Blazorise/TabsContent.razor
@@ -2,9 +2,11 @@
 @if ( !HasCustomRegistration )
 {
     <CascadingValue Value=this>
-        <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
-            @ChildContent
-        </div>
+        <CascadingValue Value="@store">
+            <div class="@ClassNames" style="@StyleNames" @attributes="@Attributes">
+                @ChildContent
+            </div>
+        </CascadingValue>
     </CascadingValue>
 }
 else

--- a/Source/Blazorise/TabsContent.razor.cs
+++ b/Source/Blazorise/TabsContent.razor.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Blazorise.Stores;
 using Microsoft.AspNetCore.Components;
 #endregion
 
@@ -14,9 +15,7 @@ namespace Blazorise
 
         private List<string> panels = new List<string>();
 
-        private string selectedPanel;
-
-        public event EventHandler<TabsContentStateEventArgs> StateChanged;
+        private TabsContentStore store = new TabsContentStore();
 
         #endregion
 
@@ -45,7 +44,9 @@ namespace Blazorise
 
         #region Properties
 
-        protected int IndexOfSelectedPanel => panels.IndexOf( selectedPanel );
+        protected TabsContentStore Store => store;
+
+        protected int IndexOfSelectedPanel => panels.IndexOf( store.SelectedPanel );
 
         /// <summary>
         /// Gets or sets currently selected panel name.
@@ -53,18 +54,17 @@ namespace Blazorise
         [Parameter]
         public string SelectedPanel
         {
-            get => selectedPanel;
+            get => store.SelectedPanel;
             set
             {
                 // prevent panels from calling the same code multiple times
-                if ( value == selectedPanel )
+                if ( value == store.SelectedPanel )
                     return;
 
-                selectedPanel = value;
+                store.SelectedPanel = value;
 
                 // raise the tabchanged notification
-                StateChanged?.Invoke( this, new TabsContentStateEventArgs( selectedPanel ) );
-                SelectedPanelChanged.InvokeAsync( selectedPanel );
+                SelectedPanelChanged.InvokeAsync( store.SelectedPanel );
 
                 DirtyClasses();
             }


### PR DESCRIPTION
This PR also fixes #672 

With this PR I introduce a new store objects that are used to hold component state.

- Use struct instead of class
- Struct is deliberately made mutable to allow easier change of properties
- Struct is also used so that every time something change the state at that time will be used as a cascading value
- Struct getters are `readonly` because of https://docs.microsoft.com/en-us/dotnet/csharp/write-safe-efficient-code#declare-readonly-members-when-a-struct-cant-be-immutable

What are the benefits:

- Can use only one `CascadingValue` instead of multiple nested for every component property that needs to be cascaded
- Remove the need for event-handlers to notify child components. 
- Can be check if the data is really changed in child component by `if ( parentDropdownStore == value )`
- Only if the store is changed we can do `DirtyClasses();`

