### PR TITLE
fix: new apis for updating chart

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Tests/ChartsPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/ChartsPage.razor
@@ -120,11 +120,7 @@
     {
         await chart.Clear();
 
-        await chart.AddLabel( Labels );
-
-        await chart.AddDataSet( getDataSet() );
-
-        await chart.Update();
+        await chart.AddLabelsDatasetsAndUpdate( Labels, getDataSet() );
     }
 
     ChartDataset<double> GetChartDataset()

--- a/Demos/Blazorise.Demo/Pages/Tests/LiveChartsPage.razor.cs
+++ b/Demos/Blazorise.Demo/Pages/Tests/LiveChartsPage.razor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Blazorise.Charts;
@@ -172,21 +173,14 @@ namespace Blazorise.Demo.Pages.Tests
         {
             await chart.Clear();
 
-            await chart.AddLabel( Labels );
-
-            foreach ( var getDataSet in getDataSets )
-            {
-                await chart.AddDataSet( getDataSet() );
-            }
-
-            await chart.Update();
+            await chart.AddLabelsDatasetsAndUpdate( Labels, getDataSets.Select( x => x.Invoke() ).ToArray() );
         }
 
         async Task AddNewHorizontalLineDataSet()
         {
             var colorIndex = horizontalLineChart.Data.Datasets.Count % backgroundColors.Count;
 
-            await horizontalLineChart.AddDataSet( new LineChartDataset<LiveDataPoint>
+            await horizontalLineChart.AddDatasetsAndUpdate( new LineChartDataset<LiveDataPoint>
             {
                 Data = new List<LiveDataPoint>(),
                 Label = $"Dataset {horizontalLineChart.Data.Datasets.Count + 1}",
@@ -195,8 +189,6 @@ namespace Blazorise.Demo.Pages.Tests
                 Fill = false,
                 LineTension = 0,
             } );
-
-            await horizontalLineChart.Update();
         }
 
         async Task AddNewHorizontalLineData()
@@ -217,7 +209,7 @@ namespace Blazorise.Demo.Pages.Tests
         {
             var colorIndex = verticalLineChart.Data.Datasets.Count % backgroundColors.Count;
 
-            await verticalLineChart.AddDataSet( new LineChartDataset<LiveDataPoint>
+            await verticalLineChart.AddDatasetsAndUpdate( new LineChartDataset<LiveDataPoint>
             {
                 Data = new List<LiveDataPoint>(),
                 Label = $"Dataset {verticalLineChart.Data.Datasets.Count + 1}",
@@ -226,8 +218,6 @@ namespace Blazorise.Demo.Pages.Tests
                 Fill = false,
                 LineTension = 0,
             } );
-
-            await verticalLineChart.Update();
         }
 
         async Task AddNewVerticalLineData()
@@ -248,15 +238,13 @@ namespace Blazorise.Demo.Pages.Tests
         {
             var colorIndex = horizontalBarChart.Data.Datasets.Count % backgroundColors.Count;
 
-            await horizontalBarChart.AddDataSet( new BarChartDataset<LiveDataPoint>
+            await horizontalBarChart.AddDatasetsAndUpdate( new BarChartDataset<LiveDataPoint>
             {
                 Data = new List<LiveDataPoint>(),
                 Label = $"Dataset {horizontalBarChart.Data.Datasets.Count + 1}",
                 BackgroundColor = backgroundColors[colorIndex],
                 BorderColor = borderColors[colorIndex],
             } );
-
-            await horizontalBarChart.Update();
         }
 
         async Task AddNewHorizontalBarData()
@@ -277,15 +265,13 @@ namespace Blazorise.Demo.Pages.Tests
         {
             var colorIndex = verticalBarChart.Data.Datasets.Count % backgroundColors.Count;
 
-            await verticalBarChart.AddDataSet( new BarChartDataset<LiveDataPoint>
+            await verticalBarChart.AddDatasetsAndUpdate( new BarChartDataset<LiveDataPoint>
             {
                 Data = new List<LiveDataPoint>(),
                 Label = $"Dataset {verticalBarChart.Data.Datasets.Count + 1}",
                 BackgroundColor = backgroundColors[colorIndex],
                 BorderColor = borderColors[colorIndex],
             } );
-
-            await verticalBarChart.Update();
         }
 
         async Task AddNewVerticalBarData()

--- a/Source/Extensions/Blazorise.Charts/BaseChart.cs
+++ b/Source/Extensions/Blazorise.Charts/BaseChart.cs
@@ -101,8 +101,8 @@ namespace Blazorise.Charts
         {
             dirty = true;
 
-            Data?.Labels?.Clear();
-            Data?.Datasets?.Clear();
+            Labels.Clear();
+            Datasets.Clear();
 
             if ( initialized )
                 await JS.Clear( JSRuntime, ElementId );
@@ -111,41 +111,29 @@ namespace Blazorise.Charts
         /// <summary>
         /// Adds a new label to the chart.
         /// </summary>
-        /// <param name="label">Label name(s).</param>
-        public async Task AddLabel( params string[] label )
+        /// <param name="labels">Label name(s).</param>
+        public async Task AddLabel( params string[] labels )
         {
             dirty = true;
 
-            if ( Data == null )
-                Data = new ChartData<TItem>();
-
-            if ( Data.Labels == null )
-                Data.Labels = new List<string>();
-
-            Data.Labels.AddRange( label );
+            Labels.AddRange( labels );
 
             if ( initialized )
-                await JS.AddLabel( JSRuntime, ElementId, label );
+                await JS.AddLabel( JSRuntime, ElementId, labels );
         }
 
         /// <summary>
         /// Adds a new dataset to the chart.
         /// </summary>
-        /// <param name="dataSet">Data set(s).</param>
-        public async Task AddDataSet( params TDataSet[] dataSet )
+        /// <param name="datasets">Data set(s).</param>
+        public async Task AddDataSet( params TDataSet[] datasets )
         {
             dirty = true;
 
-            if ( Data == null )
-                Data = new ChartData<TItem>();
-
-            if ( Data.Datasets == null )
-                Data.Datasets = new List<ChartDataset<TItem>>();
-
-            Data.Datasets.AddRange( dataSet );
+            Datasets.AddRange( datasets );
 
             if ( initialized )
-                await JS.AddDataSet( JSRuntime, ElementId, dataSet );
+                await JS.AddDataSet( JSRuntime, ElementId, datasets );
         }
 
         /// <summary>
@@ -158,19 +146,42 @@ namespace Blazorise.Charts
         {
             dirty = true;
 
-            if ( Data == null )
-                Data = new ChartData<TItem>();
-
-            if ( Data.Datasets == null )
-                Data.Datasets = new List<ChartDataset<TItem>>();
-
-            if ( Data.Datasets[dataSetIndex].Data == null )
-                Data.Datasets[dataSetIndex].Data = new List<TItem>();
-
-            Data.Datasets[dataSetIndex].Data.AddRange( data );
+            Datasets[dataSetIndex].Data.AddRange( data );
 
             if ( initialized )
                 await JS.AddData( JSRuntime, ElementId, dataSetIndex, data );
+        }
+
+        /// <summary>
+        /// Adds new datasets and then update the chart.
+        /// </summary>
+        /// <param name="datasets">List of datasets.</param>
+        /// <returns></returns>
+        public async Task AddDatasetsAndUpdate( params TDataSet[] datasets )
+        {
+            dirty = true;
+
+            Datasets.AddRange( datasets );
+
+            if ( initialized )
+                await JS.AddDatasetsAndUpdate( JSRuntime, ElementId, datasets );
+        }
+
+        /// <summary>
+        /// Adds new set of labels and datasets and then update the chart.
+        /// </summary>
+        /// <param name="labels">List of labels.</param>
+        /// <param name="datasets">List of datasets.</param>
+        /// <returns></returns>
+        public async Task AddLabelsDatasetsAndUpdate( IReadOnlyCollection<string> labels, params TDataSet[] datasets )
+        {
+            dirty = true;
+
+            Labels.AddRange( labels );
+            Datasets.AddRange( datasets );
+
+            if ( initialized )
+                await JS.AddLabelsDatasetsAndUpdate( JSRuntime, ElementId, labels, datasets );
         }
 
         /// <summary>
@@ -254,6 +265,34 @@ namespace Blazorise.Charts
         #endregion
 
         #region Properties
+
+        protected List<string> Labels
+        {
+            get
+            {
+                if ( Data == null )
+                    Data = new ChartData<TItem>();
+
+                if ( Data.Labels == null )
+                    Data.Labels = new List<string>();
+
+                return Data.Labels;
+            }
+        }
+
+        protected List<ChartDataset<TItem>> Datasets
+        {
+            get
+            {
+                if ( Data == null )
+                    Data = new ChartData<TItem>();
+
+                if ( Data.Datasets == null )
+                    Data.Datasets = new List<ChartDataset<TItem>>();
+
+                return Data.Datasets;
+            }
+        }
 
         /// <summary>
         /// Defines the chart type.

--- a/Source/Extensions/Blazorise.Charts/JS.cs
+++ b/Source/Extensions/Blazorise.Charts/JS.cs
@@ -1,5 +1,6 @@
 #region Using directives
 using Microsoft.JSInterop;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 #endregion
@@ -29,9 +30,9 @@ namespace Blazorise.Charts
             }
         }
 
-        public static ValueTask<bool> Initialize<TItem, TOptions>( IJSRuntime runtime, DotNetObjectReference<ChartAdapter> dotNetObjectReference, bool hasClickEvent, bool hasHoverEvent, string canvasId, ChartType type, ChartData<TItem> data, TOptions options, string dataJsonString, string optionsJsonString, object optionsObject )
+        public static ValueTask Initialize<TItem, TOptions>( IJSRuntime runtime, DotNetObjectReference<ChartAdapter> dotNetObjectReference, bool hasClickEvent, bool hasHoverEvent, string canvasId, ChartType type, ChartData<TItem> data, TOptions options, string dataJsonString, string optionsJsonString, object optionsObject )
         {
-            return runtime.InvokeAsync<bool>( "blazoriseCharts.initialize",
+            return runtime.InvokeVoidAsync( "blazoriseCharts.initialize",
                 dotNetObjectReference,
                 hasClickEvent,
                 hasHoverEvent,
@@ -44,39 +45,49 @@ namespace Blazorise.Charts
                 optionsObject );
         }
 
-        public static ValueTask<bool> Destroy( IJSRuntime runtime, string canvasId )
+        public static ValueTask Destroy( IJSRuntime runtime, string canvasId )
         {
-            return runtime.InvokeAsync<bool>( "blazoriseCharts.destroy", canvasId );
+            return runtime.InvokeVoidAsync( "blazoriseCharts.destroy", canvasId );
         }
 
-        public static ValueTask<bool> SetOptions<TOptions>( IJSRuntime runtime, string canvasId, TOptions options, string optionsJsonString, object optionsObject )
+        public static ValueTask SetOptions<TOptions>( IJSRuntime runtime, string canvasId, TOptions options, string optionsJsonString, object optionsObject )
         {
-            return runtime.InvokeAsync<bool>( "blazoriseCharts.setOptions", canvasId, options, optionsJsonString, optionsObject );
+            return runtime.InvokeVoidAsync( "blazoriseCharts.setOptions", canvasId, options, optionsJsonString, optionsObject );
         }
 
-        public static ValueTask<bool> Update( IJSRuntime runtime, string canvasId )
+        public static ValueTask Update( IJSRuntime runtime, string canvasId )
         {
-            return runtime.InvokeAsync<bool>( "blazoriseCharts.update", canvasId );
+            return runtime.InvokeVoidAsync( "blazoriseCharts.update", canvasId );
         }
 
-        public static ValueTask<bool> Clear( IJSRuntime runtime, string canvasId )
+        public static ValueTask Clear( IJSRuntime runtime, string canvasId )
         {
-            return runtime.InvokeAsync<bool>( "blazoriseCharts.clear", canvasId );
+            return runtime.InvokeVoidAsync( "blazoriseCharts.clear", canvasId );
         }
 
-        public static ValueTask<bool> AddLabel( IJSRuntime runtime, string canvasId, params string[] labels )
+        public static ValueTask AddLabel( IJSRuntime runtime, string canvasId, IReadOnlyCollection<string> newLabels )
         {
-            return runtime.InvokeAsync<bool>( "blazoriseCharts.addLabel", canvasId, labels );
+            return runtime.InvokeVoidAsync( "blazoriseCharts.addLabel", canvasId, newLabels );
         }
 
-        public static ValueTask<bool> AddDataSet( IJSRuntime runtime, string canvasId, params object[] newDataSet )
+        public static ValueTask AddDataSet( IJSRuntime runtime, string canvasId, IReadOnlyCollection<object> newDataSet )
         {
-            return runtime.InvokeAsync<bool>( "blazoriseCharts.addDataset", canvasId, newDataSet );
+            return runtime.InvokeVoidAsync( "blazoriseCharts.addDataset", canvasId, newDataSet );
         }
 
-        public static ValueTask<bool> AddData<TItem>( IJSRuntime runtime, string canvasId, int dataSetIndex, params TItem[] newData )
+        public static ValueTask AddDatasetsAndUpdate( IJSRuntime runtime, string canvasId, IReadOnlyCollection<object> newDataSet )
         {
-            return runtime.InvokeAsync<bool>( "blazoriseCharts.addData", canvasId, dataSetIndex, newData );
+            return runtime.InvokeVoidAsync( "blazoriseCharts.addDatasetsAndUpdate", canvasId, newDataSet );
+        }
+
+        public static ValueTask AddLabelsDatasetsAndUpdate( IJSRuntime runtime, string canvasId, IReadOnlyCollection<string> newLabels, IReadOnlyCollection<object> newDataSet )
+        {
+            return runtime.InvokeVoidAsync( "blazoriseCharts.addLabelsDatasetsAndUpdate", canvasId, newLabels, newDataSet );
+        }
+
+        public static ValueTask AddData<TItem>( IJSRuntime runtime, string canvasId, int dataSetIndex, IReadOnlyCollection<TItem> newData )
+        {
+            return runtime.InvokeVoidAsync( "blazoriseCharts.addData", canvasId, dataSetIndex, newData );
         }
 
         public static string ToChartTypeString( ChartType type )

--- a/Source/Extensions/Blazorise.Charts/wwwroot/blazorise.charts.js
+++ b/Source/Extensions/Blazorise.Charts/wwwroot/blazorise.charts.js
@@ -32,8 +32,6 @@ window.blazoriseCharts = {
 
             window.blazoriseCharts.wireEvents(dotnetAdapter, hasClickEvent, hasHoverEvent, canvas, chart);
         }
-
-        return true;
     },
 
     destroy: (canvasId) => {
@@ -46,8 +44,6 @@ window.blazoriseCharts = {
         }
 
         delete instances[canvasId];
-
-        return true;
     },
 
     setOptions: (canvasId, options, optionsJsonString, optionsObject) => {
@@ -63,8 +59,6 @@ window.blazoriseCharts = {
         if (chart) {
             chart.options = options;
         }
-
-        return true;
     },
 
     update: (canvasId) => {
@@ -73,8 +67,6 @@ window.blazoriseCharts = {
         if (chart) {
             chart.update();
         }
-
-        return true;
     },
 
     clear: (canvasId) => {
@@ -85,8 +77,6 @@ window.blazoriseCharts = {
             chart.data.datasets = [];
             chart.update();
         }
-
-        return true;
     },
 
     addLabel: (canvasId, newLabels) => {
@@ -97,20 +87,15 @@ window.blazoriseCharts = {
                 chart.data.labels.push(label);
             });
         }
-
-        return true;
     },
 
     addDataset: (canvasId, newDatasets) => {
         const chart = window.blazoriseCharts.getChart(canvasId);
-
         if (chart) {
             newDatasets.forEach((dataset, index) => {
                 chart.data.datasets.push(dataset);
             });
         }
-
-        return true;
     },
 
     addData: (canvasId, datasetIndex, newData) => {
@@ -121,8 +106,34 @@ window.blazoriseCharts = {
                 chart.data.datasets[datasetIndex].data.push(data);
             });
         }
+    },
 
-        return true;
+    addDatasetsAndUpdate: (canvasId, newDatasets) => {
+        const chart = window.blazoriseCharts.getChart(canvasId);
+
+        if (chart) {
+            newDatasets.forEach((dataset, index) => {
+                chart.data.datasets.push(dataset);
+            });
+
+            chart.update();
+        }
+    },
+
+    addLabelsDatasetsAndUpdate: (canvasId, newLabels, newDatasets) => {
+        const chart = window.blazoriseCharts.getChart(canvasId);
+
+        if (chart) {
+            newLabels.forEach((label, index) => {
+                chart.data.labels.push(label);
+            });
+
+            newDatasets.forEach((dataset, index) => {
+                chart.data.datasets.push(dataset);
+            });
+
+            chart.update();
+        }
     },
 
     wireEvents: (dotnetAdapter, hasClickEvent, hasHoverEvent, canvas, chart) => {


### PR DESCRIPTION
#792 error with charts after redrawing

This PR adds additional APIs to handle the chart update.

- AddDatasetsAndUpdate()
- AddLabelsDatasetsAndUpdate()

The problem with separate calls to chart with Clear(), AddLabel(), AddDataset() and Update() is that chartjs for some reason will raise an exception sometimes before update is called. Since it is random I cannot find the true cause. So I introduce this new APIs that will merge several calls into one operation.
