### PR TITLE
Dev091 datagriddetail columnspan fix

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/_DataGridDetailRow.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridDetailRow.razor.cs
@@ -24,7 +24,7 @@ namespace Blazorise.DataGrid
             => Columns.Any( x => x.ColumnType == DataGridColumnType.Command );
 
         protected int ColumnSpan
-            => Columns.Count;
+            => Columns.Count - ( HasCommandColumn && !ParentDataGrid.Editable ? 1 : 0 );
 
         /// <summary>
         /// Item associated with the data set.

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridDetailRow.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridDetailRow.razor.cs
@@ -24,7 +24,7 @@ namespace Blazorise.DataGrid
             => Columns.Any( x => x.ColumnType == DataGridColumnType.Command );
 
         protected int ColumnSpan
-            => Columns.Count - ( HasCommandColumn && ParentDataGrid.Editable ? 0 : 1 );
+            => Columns.Count;
 
         /// <summary>
         /// Item associated with the data set.


### PR DESCRIPTION
Content of detail row wasn't spanning entire width of the detail row for me without a command column being specified.  Reversing subtraction logic created the same effect when command column was specified.  Decided to remove it to resolve the issue.  
I'm probably doing something wrong and have never tried creating a pull request before so feel free to straighten me out and tell me what I should do :) and if it's better to ask on gitter or just open an issue that's cool just let me know.