### PR TITLE
fix: TextEdit and MemoEdit caret jump

### DIFF
--- a/Source/Blazorise/BaseTextInput.razor.cs
+++ b/Source/Blazorise/BaseTextInput.razor.cs
@@ -53,14 +53,16 @@ namespace Blazorise
             return Task.CompletedTask;
         }
 
-        protected virtual Task OnInputHandler( ChangeEventArgs e )
+        protected virtual async Task OnInputHandler( ChangeEventArgs e )
         {
             if ( Options.ChangeTextOnKeyPress )
             {
-                return CurrentValueHandler( e?.Value?.ToString() );
-            }
+                var caret = await JSRunner.GetCaret( ElementRef );
 
-            return Task.CompletedTask;
+                await CurrentValueHandler( e?.Value?.ToString() );
+
+                await JSRunner.SetCaret( ElementRef, caret );
+            }
         }
 
         #endregion

--- a/Source/Blazorise/IJSRunner.cs
+++ b/Source/Blazorise/IJSRunner.cs
@@ -52,6 +52,10 @@ namespace Blazorise
 
         ValueTask<bool> SetTextValue( ElementReference elementRef, object value );
 
+        ValueTask SetCaret( ElementReference elementRef, int caret );
+
+        ValueTask<int> GetCaret( ElementReference elementRef );
+
         ValueTask<bool> OpenModal( ElementReference elementRef, string elementId, bool scrollToTop );
 
         ValueTask<bool> CloseModal( ElementReference elementRef, string elementId );

--- a/Source/Blazorise/JSRunner.cs
+++ b/Source/Blazorise/JSRunner.cs
@@ -167,6 +167,16 @@ namespace Blazorise
             return runtime.InvokeAsync<bool>( $"{BLAZORISE_NAMESPACE}.setTextValue", elementRef, value );
         }
 
+        public ValueTask SetCaret( ElementReference elementRef, int caret )
+        {
+            return runtime.InvokeVoidAsync( $"{BLAZORISE_NAMESPACE}.setCaret", elementRef, caret );
+        }
+
+        public ValueTask<int> GetCaret( ElementReference elementRef )
+        {
+            return runtime.InvokeAsync<int>( $"{BLAZORISE_NAMESPACE}.getCaret", elementRef );
+        }
+
         public abstract ValueTask<bool> OpenModal( ElementReference elementRef, string elementId, bool scrollToTop );
 
         public abstract ValueTask<bool> CloseModal( ElementReference elementRef, string elementId );

--- a/Source/Blazorise/MemoEdit.razor.cs
+++ b/Source/Blazorise/MemoEdit.razor.cs
@@ -45,14 +45,16 @@ namespace Blazorise
             return Task.CompletedTask;
         }
 
-        protected Task OnInputHandler( ChangeEventArgs e )
+        protected async Task OnInputHandler( ChangeEventArgs e )
         {
             if ( Options.ChangeTextOnKeyPress )
             {
-                return CurrentValueHandler( e?.Value?.ToString() );
-            }
+                var caret = await JSRunner.GetCaret( ElementRef );
 
-            return Task.CompletedTask;
+                await CurrentValueHandler( e?.Value?.ToString() );
+
+                await JSRunner.SetCaret( ElementRef, caret );
+            }
         }
 
         protected override Task OnInternalValueChanged( string value )

--- a/Source/Blazorise/wwwroot/blazorise.js
+++ b/Source/Blazorise/wwwroot/blazorise.js
@@ -97,6 +97,18 @@ window.blazorise = {
         return true;
     },
 
+    setCaret: (element, caret) => {
+        window.requestAnimationFrame(() => {
+            element.selectionStart = caret;
+            element.selectionEnd = caret;
+        })
+    },
+
+    getCaret: (element) => {
+        const caret = element.selectionStart;
+        return caret;
+    },
+
     getSelectedOptions: (elementId) => {
         const element = document.getElementById(elementId);
         const len = element.options.length;


### PR DESCRIPTION
#655 Memo cursor jumps to end when enclosed in a field and Text is bound
#733 TextEdit jump caret to the end of the text for every typed char, when ChangeTextOnKeyPress is true.

Fixes the bug with caret jumping to the end of input when `Text` is set to **two-way** binding and `Options.ChangeTextOnKeyPress` is set to true.