### PR TITLE
Fix Convertor.ToDictionary for Arrays and Lists

### DIFF
--- a/Source/Blazorise/Utils/Converters.cs
+++ b/Source/Blazorise/Utils/Converters.cs
@@ -95,31 +95,7 @@ namespace Blazorise.Utils
 
                 if ( value != null && ( emitDefaultValue || !IsEqualToDefaultValue( value ) ) )
                 {
-                    //var type = value.GetType();
-
                     dictionary.Add( propertyName, ProcessValue( value, emitDefaultValue ) );
-
-                    //if ( IsSimpleType( type ) )
-                    //{
-                    //    dictionary.Add( propertyName, value );
-                    //}
-                    //else if ( typeof( IEnumerable ).IsAssignableFrom( type ) )
-                    //{
-                    //    var list = new List<object>();
-                    //    foreach ( var item in value as IEnumerable )
-                    //    {
-
-                    //    }
-                    //}
-                    //else
-                    //{
-                    //    var dict = ToDictionary( value, addEmptyObjects );
-
-                    //    if ( addEmptyObjects || dict.Count > 0 )
-                    //    {
-                    //        dictionary.Add( propertyName, dict );
-                    //    }
-                    //}
                 }
             }
 

--- a/Tests/Blazorise.Tests/Utils/ConvertersTests.cs
+++ b/Tests/Blazorise.Tests/Utils/ConvertersTests.cs
@@ -1,4 +1,8 @@
-﻿using System.Runtime.Serialization;
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text.Json;
 using Blazorise.Utils;
 using Xunit;
 
@@ -25,7 +29,8 @@ namespace Blazorise.Tests.Utils
                 integer = 42,
                 integerWithDefault = default( int ),
                 nullableInteger = (int?)43,
-                nullableIntegerWithNull = (int?)null
+                nullableIntegerWithNull = (int?)null,
+                stringValue = "test"
             };
 
             // Act
@@ -33,10 +38,11 @@ namespace Blazorise.Tests.Utils
 
             // Assert
             Assert.NotNull( result );
-            Assert.Equal( 3, result.Count );
+            Assert.Equal( 4, result.Count );
             Assert.Equal( 42, result["integer"] );
             Assert.Equal( 0, result["integerWithDefault"] );
             Assert.Equal( 43, result["nullableInteger"] );
+            Assert.Equal( "test", result["stringValue"] );
         }
 
         [Fact]
@@ -61,6 +67,168 @@ namespace Blazorise.Tests.Utils
             Assert.Equal( 42, result["integer"] );
             Assert.Equal( 0, result["integerWithDefaultOk"] );
             Assert.Equal( 43, result["nullableInteger"] );
+        }
+
+        [Fact]
+        public void ToDictionary_With_NestedObject_Should_Create_Correct_Result()
+        {
+            // Arrange
+            var test = new Test
+            {
+                Integer = 42,
+                NestedTest = new NestedTest
+                {
+                    Boolean = true,
+                    StringValue = "test"
+                }
+            };
+
+            // Act
+            var result = Converters.ToDictionary( test );
+
+            // Assert
+            Assert.NotNull( result );
+            Assert.Equal( 3, result.Count );
+            Assert.Equal( 42, result["integer"] );
+            Assert.Equal( 0, result["integerWithDefaultOk"] );
+
+            var nested = result["nestedTest"] as Dictionary<string, object>;
+            Assert.NotNull( nested );
+            Assert.Equal( true, nested["boolean"] );
+        }
+
+        [Fact]
+        public void ToDictionary_With_SimpleArray_Should_Create_Correct_Result()
+        {
+            // Arrange
+            var test = new Test
+            {
+                Integer = 42,
+                SimpleArray = new[] { 1, 2, 3 }
+            };
+
+            // Act
+            var result = Converters.ToDictionary( test );
+
+            // Assert
+            Assert.NotNull( result );
+            Assert.Equal( 3, result.Count );
+            Assert.Equal( 42, result["integer"] );
+            Assert.Equal( 0, result["integerWithDefaultOk"] );
+
+            var simpleArray = result["simpleArray"] as object[];
+            Assert.NotNull( simpleArray );
+            Assert.Equal( 3, simpleArray.Length );
+            Assert.Equal( new object[] { 1, 2, 3 }, simpleArray );
+        }
+
+        [Fact]
+        public void ToDictionary_With_SimpleList_Should_Create_Correct_Result()
+        {
+            // Arrange
+            var test = new Test
+            {
+                Integer = 42,
+                SimpleList = new List<int> { 1, 2, 3 }
+            };
+
+            // Act
+            var result = Converters.ToDictionary( test );
+
+            // Assert
+            Assert.NotNull( result );
+            Assert.Equal( 3, result.Count );
+            Assert.Equal( 42, result["integer"] );
+            Assert.Equal( 0, result["integerWithDefaultOk"] );
+
+            var simpleList = result["simpleList"] as List<object>;
+            Assert.NotNull( simpleList );
+            Assert.Equal( 3, simpleList.Count );
+            Assert.Equal( new List<int> { 1, 2, 3 }, simpleList.Cast<int>().ToList() );
+        }
+
+        [Fact]
+        public void ToDictionary_With_ComplexArray_Should_Create_Correct_Result()
+        {
+            // Arrange
+            var test = new Test
+            {
+                Integer = 42,
+                ComplexArray = new[]
+                {
+                    new NestedTest { Boolean = true, StringValue = "test1" },
+                    new NestedTest { Boolean = true, StringValue = null },
+                    new NestedTest { Boolean = false, StringValue = "test3" }
+                }
+            };
+
+            // Act
+            var result = Converters.ToDictionary( test );
+
+            // Assert
+            Assert.NotNull( result );
+            Assert.Equal( 3, result.Count );
+            Assert.Equal( 42, result["integer"] );
+            Assert.Equal( 0, result["integerWithDefaultOk"] );
+
+            var nestedArray = result["complexArray"] as object[];
+            Assert.NotNull( nestedArray );
+            Assert.Equal( 3, nestedArray.Length );
+
+            var arrayItem1 = nestedArray[0] as Dictionary<string, object>;
+            Assert.Equal( 2, arrayItem1.Count );
+            Assert.Equal( true, arrayItem1["boolean"] );
+            Assert.Equal( "test1", arrayItem1["stringValue"] );
+
+            var arrayItem2 = nestedArray[1] as Dictionary<string, object>;
+            Assert.Single( arrayItem2 );
+            Assert.Equal( true, arrayItem2["boolean"] );
+
+            var arrayItem3 = nestedArray[2] as Dictionary<string, object>;
+            Assert.Single( arrayItem3 );
+            Assert.Equal( "test3", arrayItem3["stringValue"] );
+        }
+
+        [Fact]
+        public void ToDictionary_With_ComplexList_Should_Create_Correct_Result()
+        {
+            // Arrange
+            var test = new Test
+            {
+                Integer = 42,
+                ComplexList = new List<NestedTest>
+                {
+                    new NestedTest { Boolean = true, StringValue = "test1" },
+                    new NestedTest { Boolean = true, StringValue = null },
+                    new NestedTest { Boolean = false, StringValue = "test3" }
+                }
+            };
+
+            // Act
+            var result = Converters.ToDictionary( test );
+
+            // Assert
+            Assert.NotNull( result );
+            Assert.Equal( 3, result.Count );
+            Assert.Equal( 42, result["integer"] );
+            Assert.Equal( 0, result["integerWithDefaultOk"] );
+
+            var complexList = result["complexList"] as List<object>;
+            Assert.NotNull( complexList );
+            Assert.Equal( 3, complexList.Count );
+
+            var item1 = complexList[0] as Dictionary<string, object>;
+            Assert.Equal( 2, item1.Count );
+            Assert.Equal( true, item1["boolean"] );
+            Assert.Equal( "test1", item1["stringValue"] );
+
+            var item2 = complexList[1] as Dictionary<string, object>;
+            Assert.Single( item2 );
+            Assert.Equal( true, item2["boolean"] );
+
+            var item3 = complexList[2] as Dictionary<string, object>;
+            Assert.Single( item3 );
+            Assert.Equal( "test3", item3["stringValue"] );
         }
 
         [Fact]
@@ -133,6 +301,30 @@ namespace Blazorise.Tests.Utils
 
         [DataMember( EmitDefaultValue = false )]
         public int? NullableIntegerWithNull { get; set; }
+
+        [DataMember( EmitDefaultValue = false )]
+        public NestedTest NestedTest { get; set; }
+
+        [DataMember( EmitDefaultValue = false )]
+        public int[] SimpleArray { get; set; }
+
+        [DataMember( EmitDefaultValue = false )]
+        public List<int> SimpleList { get; set; }
+
+        [DataMember( EmitDefaultValue = false )]
+        public NestedTest[] ComplexArray { get; set; }
+
+        [DataMember( EmitDefaultValue = false )]
+        public List<NestedTest> ComplexList { get; set; }
+    }
+
+    public class NestedTest
+    {
+        [DataMember( EmitDefaultValue = false )]
+        public bool Boolean { get; set; }
+
+        [DataMember( EmitDefaultValue = false )]
+        public string StringValue { get; set; }
     }
 
     public class TestWithDataMemberName


### PR DESCRIPTION
Sorry @stsrki,
I tried to use my own convertor code for the chartjs, and I noticed that some things were wrong.

The problem was that Arrays and Lists were not correctly processed.
So the arrays yAxes and xAxes where passed to the javascript as:
``` js
{"barPercentage":0.899999976,"categoryPercentage":0.800000012,"barThickness":0,"maxBarThickness":0,"scales":{"xAxes":{"capacity":4,"count":1},"yAxes":{"capacity":4,"count":1}},"responsive":true,"maintainAspectRatio":true,"aspectRatio":2}
```

this has been fixed in this PR + I've aded some more tests for nested objects, simple-arrays, complex-arrays, simple-lists and complex-lists.