### PR TITLE
Fixes for DataGrid manual data read behavior

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -77,9 +77,9 @@
             }
         </TableHeader>
         <TableBody>
-            @if ( IsDisplayDataVisible || (Editable && editState == DataGridEditState.New && EditMode != DataGridEditMode.Popup) )
+            @if ( IsDisplayDataVisible || IsNewItemInGrid )
             {
-                @if ( Editable && editState == DataGridEditState.New && EditMode != DataGridEditMode.Popup )
+                @if ( IsNewItemInGrid )
                 {
                     <_DataGridRowEdit TItem="TItem" Item="@editItem" Columns="@Columns" CellValues="@editItemCellValues" Save="@OnSaveCommand" Cancel="@OnCancelCommand" EditMode="@EditMode" />
                 }
@@ -107,11 +107,11 @@
                 }
             }
         </TableBody>
-        @if ( IsEmptyTemplateVisible && !IsLoadingTemplateVisible && !(Editable && editState == DataGridEditState.New && EditMode != DataGridEditMode.Popup))
+        @if ( IsEmptyTemplateVisible && !IsLoadingTemplateVisible && !IsNewItemInGrid )
         {
             @EmptyTemplate
         }
-        @if ( IsLoadingTemplateVisible && !(Editable && editState == DataGridEditState.New && EditMode != DataGridEditMode.Popup))
+        @if ( IsLoadingTemplateVisible && !IsNewItemInGrid )
         {
             @LoadingTemplate
         }

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -77,7 +77,7 @@
             }
         </TableHeader>
         <TableBody>
-            @if ( IsDisplayDataVisible )
+            @if ( IsDisplayDataVisible || (Editable && editState == DataGridEditState.New && EditMode != DataGridEditMode.Popup) )
             {
                 @if ( Editable && editState == DataGridEditState.New && EditMode != DataGridEditMode.Popup )
                 {
@@ -107,11 +107,11 @@
                 }
             }
         </TableBody>
-        @if ( IsEmptyTemplateVisible )
+        @if ( IsEmptyTemplateVisible && !IsLoadingTemplateVisible && !(Editable && editState == DataGridEditState.New && EditMode != DataGridEditMode.Popup))
         {
             @EmptyTemplate
         }
-        @if ( IsLoadingTemplateVisible )
+        @if ( IsLoadingTemplateVisible && !(Editable && editState == DataGridEditState.New && EditMode != DataGridEditMode.Popup))
         {
             @LoadingTemplate
         }
@@ -122,7 +122,7 @@
             </TableFooter>
         }
     </Table>
-    @if ( ShowPager )
+    @if ( ShowPager && !IsEmptyTemplateVisible && !IsLoadingTemplateVisible )
     {
         <Pagination>
             <PaginationItem Disabled="@(CurrentPage <= 1)">

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -201,6 +201,13 @@ namespace Blazorise.DataGrid
                     dirtyFilter = dirtyView = true;
                 }
             }
+
+            // When deleting and the page becomes empty and we aren't the first page:
+            //   go to the previous page
+            if ( ManualReadMode && ShowPager && CurrentPage > FirstVisiblePage && !Data.Any() )
+            {
+                await OnPaginationItemClick( ( CurrentPage - 1 ).ToString() );
+            }
         }
 
         protected async Task OnSaveCommand()
@@ -235,6 +242,10 @@ namespace Blazorise.DataGrid
                 {
                     await RowInserted.InvokeAsync( new SavedRowItem<TItem, Dictionary<string, object>>( editItem, editedCellValues ) );
                     dirtyFilter = dirtyView = true;
+                    // If a new item is added, the data should be refreshed
+                    // to account for paging, sorting, and filtering
+                    if ( ManualReadMode )
+                        await HandleReadData();
                 }
                 else
                     await RowUpdated.InvokeAsync( new SavedRowItem<TItem, Dictionary<string, object>>( editItem, editedCellValues ) );

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -203,7 +203,7 @@ namespace Blazorise.DataGrid
             }
 
             // When deleting and the page becomes empty and we aren't the first page:
-            //   go to the previous page
+            // go to the previous page
             if ( ManualReadMode && ShowPager && CurrentPage > FirstVisiblePage && !Data.Any() )
             {
                 await OnPaginationItemClick( ( CurrentPage - 1 ).ToString() );
@@ -242,6 +242,7 @@ namespace Blazorise.DataGrid
                 {
                     await RowInserted.InvokeAsync( new SavedRowItem<TItem, Dictionary<string, object>>( editItem, editedCellValues ) );
                     dirtyFilter = dirtyView = true;
+
                     // If a new item is added, the data should be refreshed
                     // to account for paging, sorting, and filtering
                     if ( ManualReadMode )
@@ -566,6 +567,11 @@ namespace Blazorise.DataGrid
         /// Returns true if EmptyTemplate is set and Data is null or empty.
         /// </summary>
         protected bool IsEmptyTemplateVisible => EmptyTemplate != null && ( Data == null || !Data.Any() );
+
+        /// <summary>
+        /// Returns true if current state is for new item and editing fields are shown on datagrid.
+        /// </summary>
+        protected bool IsNewItemInGrid => Editable && editState == DataGridEditState.New && EditMode != DataGridEditMode.Popup;
 
         /// <summary>
         /// True if user is using <see cref="ReadData"/> for loading the data.

--- a/docs/_docs/extensions/chart.md
+++ b/docs/_docs/extensions/chart.md
@@ -78,7 +78,7 @@ You should always define `TItem` data type.
     {
         await lineChart.Clear();
 
-        await chart.AddLabelsDatasetsAndUpdate( Labels, GetLineChartDataset() );
+        await lineChart.AddLabelsDatasetsAndUpdate( Labels, GetLineChartDataset() );
     }
 
     LineChartDataset<double> GetLineChartDataset()


### PR DESCRIPTION
A couple fixes for the following scenarios:

- New form isn't shown when the data is empty and the edit mode is set to Form
- The empty template and loading template both show when loading and empty
- Hide the pager when the data is empty or while loading data
- Fixed the scenario when manual data read is being used and a new item is added the view isn't refreshed respecting the sorting, filtering, and paging
- Fixed the scenario when manual data read is being used and an item is deleted on a page and the page becomes empty