### PR TITLE
 DataGrid. Title property for modal dialog. 

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
@@ -179,6 +179,12 @@
                             </DataGrid>
                         }
                     </DetailRowTemplate>
+										<PopupTitleTemplate>
+											@if(context.EditState == DataGridEditState.Edit)
+												@("Edit Employee " + context.Item.FirstName + " " + context.Item.LastName)
+											else
+												@("Create Employee")
+										</PopupTitleTemplate>
                 </DataGrid>
             </CardBody>
         </Card>

--- a/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
@@ -180,10 +180,14 @@
                         }
                     </DetailRowTemplate>
                     <PopupTitleTemplate>
-                      @if(context.EditState == DataGridEditState.Edit)
-                        @("Edit Employee " + context.Item.FirstName + " " + context.Item.LastName)
-                      else
-                        @("Create Employee")
+                        @if ( context.EditState == DataGridEditState.Edit )
+                        {
+                            @($"Edit Employee {context.Item.FirstName} {context.Item.LastName}")
+                        }
+                        else
+                        {
+                            @("Create Employee")
+                        }
                     </PopupTitleTemplate>
                 </DataGrid>
             </CardBody>

--- a/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
@@ -179,12 +179,12 @@
                             </DataGrid>
                         }
                     </DetailRowTemplate>
-										<PopupTitleTemplate>
-											@if(context.EditState == DataGridEditState.Edit)
-												@("Edit Employee " + context.Item.FirstName + " " + context.Item.LastName)
-											else
-												@("Create Employee")
-										</PopupTitleTemplate>
+                    <PopupTitleTemplate>
+                      @if(context.EditState == DataGridEditState.Edit)
+                        @("Edit Employee " + context.Item.FirstName + " " + context.Item.LastName)
+                      else
+                        @("Create Employee")
+                    </PopupTitleTemplate>
                 </DataGrid>
             </CardBody>
         </Card>

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -193,30 +193,30 @@
     }
     @if ( editItem != null && EditMode == DataGridEditMode.Popup )
     {
-			@if (PopupTitleTemplate == null)
-			{
-        <_DataGridModal TItem="TItem"
-                        EditItem="@editItem"
-                        EditItemCellValues="@editItemCellValues"
-                        Columns="@Columns"
-                        PopupVisible="@PopupVisible"
-                        EditState="@editState"
-                        Save="@OnSaveCommand"
-                        Cancel="@OnCancelCommand"/>
-			}
-			else
-			{
-        <_DataGridModal TItem="TItem"
-												TitleTemplate="PopupTitleTemplate"
-                        EditItem="@editItem"
-                        EditItemCellValues="@editItemCellValues"
-                        Columns="@Columns"
-                        PopupVisible="@PopupVisible"
-                        EditState="@editState"
-                        Save="@OnSaveCommand"
-                        Cancel="@OnCancelCommand"/>
-				}
-			}
+        @if ( PopupTitleTemplate == null )
+        {
+            <_DataGridModal TItem="TItem"
+                            EditItem="@editItem"
+                            EditItemCellValues="@editItemCellValues"
+                            Columns="@Columns"
+                            PopupVisible="@PopupVisible"
+                            EditState="@editState"
+                            Save="@OnSaveCommand"
+                            Cancel="@OnCancelCommand"/>
+        }
+        else
+        {
+            <_DataGridModal TItem="TItem"
+                            TitleTemplate="PopupTitleTemplate"
+                            EditItem="@editItem"
+                            EditItemCellValues="@editItemCellValues"
+                            Columns="@Columns"
+                            PopupVisible="@PopupVisible"
+                            EditState="@editState"
+                            Save="@OnSaveCommand"
+                            Cancel="@OnCancelCommand"/>
+          }
+      }
 </CascadingValue>
 @* This one is to hold information about columns *@
 <CascadingValue Value=this>

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -193,29 +193,15 @@
     }
     @if ( editItem != null && EditMode == DataGridEditMode.Popup )
     {
-        @if ( PopupTitleTemplate == null )
-        {
-            <_DataGridModal TItem="TItem"
-                            EditItem="@editItem"
-                            EditItemCellValues="@editItemCellValues"
-                            Columns="@Columns"
-                            PopupVisible="@PopupVisible"
-                            EditState="@editState"
-                            Save="@OnSaveCommand"
-                            Cancel="@OnCancelCommand"/>
-        }
-        else
-        {
-            <_DataGridModal TItem="TItem"
-                            TitleTemplate="PopupTitleTemplate"
-                            EditItem="@editItem"
-                            EditItemCellValues="@editItemCellValues"
-                            Columns="@Columns"
-                            PopupVisible="@PopupVisible"
-                            EditState="@editState"
-                            Save="@OnSaveCommand"
-                            Cancel="@OnCancelCommand"/>
-          }
+        <_DataGridModal TItem="TItem"
+                        TitleTemplate="PopupTitleTemplate"
+                        EditItem="@editItem"
+                        EditItemCellValues="@editItemCellValues"
+                        Columns="@Columns"
+                        PopupVisible="@PopupVisible"
+                        EditState="@editState"
+                        Save="@OnSaveCommand"
+                        Cancel="@OnCancelCommand"/>
       }
 </CascadingValue>
 @* This one is to hold information about columns *@

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -201,8 +201,8 @@
                         PopupVisible="@PopupVisible"
                         EditState="@editState"
                         Save="@OnSaveCommand"
-                        Cancel="@OnCancelCommand"/>
-      }
+                        Cancel="@OnCancelCommand" />
+    }
 </CascadingValue>
 @* This one is to hold information about columns *@
 <CascadingValue Value=this>

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -193,6 +193,8 @@
     }
     @if ( editItem != null && EditMode == DataGridEditMode.Popup )
     {
+			@if (PopupTitleTemplate == null)
+			{
         <_DataGridModal TItem="TItem"
                         EditItem="@editItem"
                         EditItemCellValues="@editItemCellValues"
@@ -200,8 +202,21 @@
                         PopupVisible="@PopupVisible"
                         EditState="@editState"
                         Save="@OnSaveCommand"
-                        Cancel="@OnCancelCommand" />
-    }
+                        Cancel="@OnCancelCommand"/>
+			}
+			else
+			{
+        <_DataGridModal TItem="TItem"
+												TitleTemplate="PopupTitleTemplate"
+                        EditItem="@editItem"
+                        EditItemCellValues="@editItemCellValues"
+                        Columns="@Columns"
+                        PopupVisible="@PopupVisible"
+                        EditState="@editState"
+                        Save="@OnSaveCommand"
+                        Cancel="@OnCancelCommand"/>
+				}
+			}
 </CascadingValue>
 @* This one is to hold information about columns *@
 <CascadingValue Value=this>

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -194,7 +194,7 @@
     @if ( editItem != null && EditMode == DataGridEditMode.Popup )
     {
         <_DataGridModal TItem="TItem"
-                        TitleTemplate="PopupTitleTemplate"
+                        TitleTemplate="@PopupTitleTemplate"
                         EditItem="@editItem"
                         EditItemCellValues="@editItemCellValues"
                         Columns="@Columns"

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -596,7 +596,7 @@ namespace Blazorise.DataGrid
         {
             return builder =>
             {
-                builder.AddContent(0, context.EditState == DataGridEditState.Edit ? "Row Edit" : "Row Create");
+                builder.AddContent( 0, context.EditState == DataGridEditState.Edit ? "Row Edit" : "Row Create" );
             };
         };
 

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -591,7 +591,14 @@ namespace Blazorise.DataGrid
         /// <summary>
         /// Gets template for title of popup modal.
         /// </summary>
-        [Parameter] public RenderFragment<PopupTitleContext<TItem>> PopupTitleTemplate { get; set; }
+        [Parameter]
+        public RenderFragment<PopupTitleContext<TItem>> PopupTitleTemplate { get; set; } = context =>
+        {
+            return builder =>
+            {
+                builder.AddContent(0, context.EditState == DataGridEditState.Edit ? "Row Edit" : "Row Create");
+            };
+        };
 
         /// <summary>
         /// Gets the flag which indicates if popup editor is visible.

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -589,6 +589,11 @@ namespace Blazorise.DataGrid
         public DataGridEditState EditState => editState;
 
         /// <summary>
+        /// Gets template for title of popup modal.
+        /// </summary>
+        [Parameter] public RenderFragment<PopupTitleContext<TItem>> PopupTitleTemplate { get; set; }
+
+        /// <summary>
         /// Gets the flag which indicates if popup editor is visible.
         /// </summary>
         protected bool PopupVisible = false;

--- a/Source/Extensions/Blazorise.DataGrid/PopupTitleContext.cs
+++ b/Source/Extensions/Blazorise.DataGrid/PopupTitleContext.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Blazorise.DataGrid
+{
+    public class PopupTitleContext<TItem>
+    {
+        public PopupTitleContext( TItem item, DataGridEditState editState )
+        {
+            Item = item;
+            EditState = editState;
+        }
+
+        /// <summary>
+        /// Gets the model.
+        /// </summary>
+        public TItem Item { get; }
+
+        /// <summary>
+        /// Gets the edit state of data grid.
+        /// </summary>
+        public DataGridEditState EditState { get; }
+    }
+}

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor
@@ -5,10 +5,10 @@
     <ModalContent>
         <ModalHeader>
             <ModalTitle>
-								@if(TitleTemplate == null)
-									@(EditState == DataGridEditState.Edit ? "Row Edit" : "Row Create")
-								else
-									@TitleTemplate(new PopupTitleContext<TItem>(EditItem, EditState))
+                @if( TitleTemplate == null )
+                    @(EditState == DataGridEditState.Edit ? "Row Edit" : "Row Create")
+                else
+                    @TitleTemplate( new PopupTitleContext<TItem>( EditItem, EditState ) )
             </ModalTitle>
             <CloseButton Clicked="@Cancel" />
         </ModalHeader>

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor
@@ -5,10 +5,14 @@
     <ModalContent>
         <ModalHeader>
             <ModalTitle>
-                @if( TitleTemplate == null || EditItem == null)
+                @if ( TitleTemplate == null || EditItem == null )
+                {
                     @(EditState == DataGridEditState.Edit ? "Row Edit" : "Row Create")
+                }
                 else
+                {
                     @TitleTemplate( new PopupTitleContext<TItem>( EditItem, EditState ) )
+                }
             </ModalTitle>
             <CloseButton Clicked="@Cancel" />
         </ModalHeader>

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor
@@ -5,7 +5,7 @@
     <ModalContent>
         <ModalHeader>
             <ModalTitle>
-                @if( TitleTemplate == null )
+                @if( TitleTemplate == null || EditItem == null)
                     @(EditState == DataGridEditState.Edit ? "Row Edit" : "Row Create")
                 else
                     @TitleTemplate( new PopupTitleContext<TItem>( EditItem, EditState ) )

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor
@@ -5,7 +5,10 @@
     <ModalContent>
         <ModalHeader>
             <ModalTitle>
-                Row Edit
+								@if(TitleTemplate == null)
+									@(EditState == DataGridEditState.Edit ? "Row Edit" : "Row Create")
+								else
+									@TitleTemplate(new PopupTitleContext<TItem>(EditItem, EditState))
             </ModalTitle>
             <CloseButton Clicked="@Cancel" />
         </ModalHeader>

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor
@@ -5,13 +5,13 @@
     <ModalContent>
         <ModalHeader>
             <ModalTitle>
-                @if ( TitleTemplate == null || EditItem == null )
+                @if ( TitleTemplate != null && EditItem != null )
                 {
-                    @(EditState == DataGridEditState.Edit ? "Row Edit" : "Row Create")
+                    @TitleTemplate( new PopupTitleContext<TItem>( EditItem, EditState ) )
                 }
                 else
                 {
-                    @TitleTemplate( new PopupTitleContext<TItem>( EditItem, EditState ) )
+                    @(EditState == DataGridEditState.Edit ? "Row Edit" : "Row Create")
                 }
             </ModalTitle>
             <CloseButton Clicked="@Cancel" />

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor.cs
@@ -12,6 +12,8 @@ namespace Blazorise.DataGrid
     {
         [Parameter] public TItem EditItem { get; set; }
 
+        [Parameter] public RenderFragment<PopupTitleContext<TItem>> TitleTemplate { get; set; }
+
         [Parameter] public IEnumerable<DataGridColumn<TItem>> Columns { get; set; }
 
         [Parameter] public IReadOnlyDictionary<string, CellEditContext> EditItemCellValues { get; set; }

--- a/docs/_docs/extensions/datagrid.md
+++ b/docs/_docs/extensions/datagrid.md
@@ -513,6 +513,7 @@ If you want to change display of content, while grid is empty or `ReadData` is e
 | PageChanged            | EventCallback                                                       |         | Occurs after the selected page has changed.                                                                 |
 | EmptyTemplate            | RenderingFragment                                                       |         | Define the format for empty data collection                                                                 |
 | LoadingTemplate            | RenderingFragment                                                       |         | Define the format for signal of loading data                                                                 |
+| PopupTitleTemplate        | `RenderFragment<PopupTitleContext<TItem>>`                          |         | Template for custom title of popup modal                                                                      |
 
 ### EditMode
 
@@ -551,4 +552,3 @@ Specifies the grid editing modes.
 | DisplayTemplate           | `RenderFragment<TItem>`                                             |         | Template for custom cell display formating.                                                                   |
 | EditTemplate              | `RenderFragment<CellEditContext>`                                   |         | Template for custom cell editing.                                                                             |
 | FilterTemplate            | `RenderFragment<FilterContext>`                                     |         | Template for custom column filter rendering.                                                                  |
-| PopupTitleTemplate        | `RenderFragment<PopupTitleContext<TItem>>`                          |         | Template for custom title of popup modal                                                                      |

--- a/docs/_docs/extensions/datagrid.md
+++ b/docs/_docs/extensions/datagrid.md
@@ -551,3 +551,4 @@ Specifies the grid editing modes.
 | DisplayTemplate           | `RenderFragment<TItem>`                                             |         | Template for custom cell display formating.                                                                   |
 | EditTemplate              | `RenderFragment<CellEditContext>`                                   |         | Template for custom cell editing.                                                                             |
 | FilterTemplate            | `RenderFragment<FilterContext>`                                     |         | Template for custom column filter rendering.                                                                  |
+| PopupTitleTemplate        | `RenderFragment<PopupTitleContext<TItem>>`                          |         | Template for custom title of popup modal                                                                      |


### PR DESCRIPTION
- Add PopupTitleContext class
- Add TitleTemplate to _DataGridModal
- Add PopupTitleTemplate property to DataGrid
- Use PopupTitleTemplate for set TitleTemplate of _DataGridModal
- Create example of PopupTitleTemplate on DataGridPage
- Extend DataGrid documentation for PopupTitleTemplate

PR is made for feature proposal #918 
This PR also resolve a part of #1064