### PR TITLE
Fixed invalid classname for ModalContent size

### DIFF
--- a/Source/Blazorise.Bootstrap/ModalContent.razor.cs
+++ b/Source/Blazorise.Bootstrap/ModalContent.razor.cs
@@ -33,7 +33,9 @@ namespace Blazorise.Bootstrap
 
         private void BuildDialogClasses( ClassBuilder builder )
         {
-            builder.Append( $"modal-dialog modal-{ClassProvider.ToModalSize( Size )}" );
+            builder.Append( $"modal-dialog" );
+            builder.Append( $"modal-{ClassProvider.ToModalSize( Size )}", Size != ModalSize.Default );
+
             builder.Append( ClassProvider.ModalContentCentered(), Centered );
         }
 

--- a/Source/Blazorise/Enums.cs
+++ b/Source/Blazorise/Enums.cs
@@ -982,11 +982,6 @@ namespace Blazorise
     public enum ModalSize
     {
         /// <summary>
-        /// No sizing applied.
-        /// </summary>
-        None,
-
-        /// <summary>
         /// Default modal size.
         /// </summary>
         Default,

--- a/Source/Blazorise/ModalContent.razor.cs
+++ b/Source/Blazorise/ModalContent.razor.cs
@@ -25,7 +25,7 @@ namespace Blazorise
         protected override void BuildClasses( ClassBuilder builder )
         {
             builder.Append( ClassProvider.ModalContent( Dialog ) );
-            builder.Append( ClassProvider.ModalContentSize( Size ), Size != ModalSize.None );
+            builder.Append( ClassProvider.ModalContentSize( Size ), Size != ModalSize.Default );
 
             base.BuildClasses( builder );
         }

--- a/docs/_docs/helpers/sizes.md
+++ b/docs/_docs/helpers/sizes.md
@@ -32,7 +32,6 @@ Defines a button size.
 
 Changes the size of the modal.
 
-- `None` No sizing applied.
 - `Default` Default modal size for current provider.
 - `Small` Small modal.
 - `Large` Large modal.


### PR DESCRIPTION
#1065 Bootstrap ModalContent generating invalid class name

- Removed `ModalSize.Null` in favor of `ModalSize.Default`
- Updated docs