### PR TITLE
fix: Resolved Bar issue relating to recent Layout Improvements

### DIFF
--- a/Source/Blazorise.AntDesign/Styles/_bar.scss
+++ b/Source/Blazorise.AntDesign/Styles/_bar.scss
@@ -119,7 +119,7 @@
     &.ant-menu-vertical {
         display: flex;
         flex-flow: column;
-        height: 100vh;
+        height: 100%;
         overflow-y: auto;
 
         .ant-menu-label {

--- a/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
+++ b/Source/Blazorise.AntDesign/wwwroot/blazorise.antdesign.css
@@ -121,7 +121,7 @@
 .ant-menu.ant-menu-root.ant-menu-inline, .ant-menu.ant-menu-root.ant-menu-vertical {
     display: flex;
     flex-flow: column;
-    height: 100vh;
+    height: 100%;
     overflow-y: auto; }
     .ant-menu.ant-menu-root.ant-menu-inline .ant-menu-label, .ant-menu.ant-menu-root.ant-menu-vertical .ant-menu-label {
         background: transparent;

--- a/Source/Blazorise/Styles/_bar.scss
+++ b/Source/Blazorise/Styles/_bar.scss
@@ -52,7 +52,9 @@
 .b-bar-vertical-inline,
 .b-bar-vertical-popout,
 .b-bar-vertical-small {
-    display: inline-block !important;
+    display: flex;
+    flex-direction: column;
+    flex-wrap: nowrap;
     position: sticky;
     top: 0;
     padding: 0;
@@ -64,17 +66,19 @@
     height: 100%;
 
     .b-bar-menu {
-        height: calc(100% - var(--b-vertical-bar-brand-height, 64px));
+        width: 100%;
+        display: flex;
+        flex: 1;
         justify-content: space-between;
         flex-direction: column;
-        display: flex !important;
+        align-self: stretch;
     }
 
     .b-bar-brand {
         width: 100%;
         display: flex;
-        margin: 0;
         height: var(--b-vertical-bar-brand-height, 64px);
+        min-height: var(--b-vertical-bar-brand-height, 64px);
     }
 
     .b-bar-item {
@@ -83,21 +87,22 @@
         min-height: 40px;
 
         .b-bar-icon {
-            font-size: 18px;
+            font-size: 1.25rem;
+            vertical-align: middle;
             margin: 3px;
         }
     }
 
     .b-bar-start {
         width: 100%;
-        display: inline-block;
+        display: block;
     }
 
     .b-bar-end {
         padding-bottom: 1rem;
         width: 100%;
         padding-top: 1rem;
-        display: inline-block;
+        display: block;
     }
 
     .b-bar-link {

--- a/Source/Blazorise/wwwroot/blazorise.css
+++ b/Source/Blazorise/wwwroot/blazorise.css
@@ -242,7 +242,9 @@
 .b-bar-vertical-inline,
 .b-bar-vertical-popout,
 .b-bar-vertical-small {
-    display: inline-block !important;
+    display: flex;
+    flex-direction: column;
+    flex-wrap: nowrap;
     position: sticky;
     top: 0;
     padding: 0;
@@ -258,17 +260,19 @@
     .b-bar-vertical-inline .b-bar-menu,
     .b-bar-vertical-popout .b-bar-menu,
     .b-bar-vertical-small .b-bar-menu {
-        height: calc(100% - var(--b-vertical-bar-brand-height, 64px));
+        width: 100%;
+        display: flex;
+        flex: 1;
         justify-content: space-between;
         flex-direction: column;
-        display: flex !important; }
+        align-self: stretch; }
     .b-bar-vertical-inline .b-bar-brand,
     .b-bar-vertical-popout .b-bar-brand,
     .b-bar-vertical-small .b-bar-brand {
         width: 100%;
         display: flex;
-        margin: 0;
-        height: var(--b-vertical-bar-brand-height, 64px); }
+        height: var(--b-vertical-bar-brand-height, 64px);
+        min-height: var(--b-vertical-bar-brand-height, 64px); }
     .b-bar-vertical-inline .b-bar-item,
     .b-bar-vertical-popout .b-bar-item,
     .b-bar-vertical-small .b-bar-item {
@@ -278,20 +282,21 @@
         .b-bar-vertical-inline .b-bar-item .b-bar-icon,
         .b-bar-vertical-popout .b-bar-item .b-bar-icon,
         .b-bar-vertical-small .b-bar-item .b-bar-icon {
-            font-size: 18px;
+            font-size: 1.25rem;
+            vertical-align: middle;
             margin: 3px; }
     .b-bar-vertical-inline .b-bar-start,
     .b-bar-vertical-popout .b-bar-start,
     .b-bar-vertical-small .b-bar-start {
         width: 100%;
-        display: inline-block; }
+        display: block; }
     .b-bar-vertical-inline .b-bar-end,
     .b-bar-vertical-popout .b-bar-end,
     .b-bar-vertical-small .b-bar-end {
         padding-bottom: 1rem;
         width: 100%;
         padding-top: 1rem;
-        display: inline-block; }
+        display: block; }
     .b-bar-vertical-inline .b-bar-link,
     .b-bar-vertical-popout .b-bar-link,
     .b-bar-vertical-small .b-bar-link {


### PR DESCRIPTION
`.b-bar-menu` still had `height: calc(100% - var(--b-vertical-bar-brand-height, 64px));`
This was causing the Bar to break when you created it _without_ a `BarBrand`.

Noticed when further testing new layout changes for "header on top" setup.

Also fixed issue with AntDesign bar.