### PR TITLE
Adding somekind of lazy loading to the tree view

### DIFF
--- a/Source/Extensions/Blazorise.TreeView/_TreeViewNode.razor
+++ b/Source/Extensions/Blazorise.TreeView/_TreeViewNode.razor
@@ -20,7 +20,7 @@
                     @NodeContent( node )
                 </_TreeViewNodeContent>
 
-                @if ( hasChildren )
+                @if ( nodeExpanded && hasChildren )
                 {
                     <_TreeViewNode Nodes="GetChildNodes(node)"
                                    NodeContent="NodeContent"


### PR DESCRIPTION
It's just one line of code, but it helped me to lower the initial loading time. By only loading the children if the root node is expanded.