### PR TITLE
Delay the text entered in TextEdit when ChangeTextOnKeyPress is true

### DIFF
--- a/Source/Blazorise/BaseTextInput.razor.cs
+++ b/Source/Blazorise/BaseTextInput.razor.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
+using Blazorise.Utils;
 using Microsoft.AspNetCore.Components;
 #endregion
 
@@ -18,6 +19,8 @@ namespace Blazorise
         #region Members
 
         private Color color;
+
+        private ValueDelayer valueDelayer;
 
         #endregion
 
@@ -35,12 +38,37 @@ namespace Blazorise
 
         protected override void OnInitialized()
         {
+            if ( IsDelayTextOnKeyPress )
+            {
+                valueDelayer = new ValueDelayer( DelayTextOnKeyPressIntervalValue );
+                valueDelayer.Delayed += DelayValue_Delayed;
+            }
+
             if ( ParentValidation != null )
             {
                 ParentValidation.InitializeInputPattern( Pattern );
             }
 
             base.OnInitialized();
+        }
+
+        protected override void Dispose( bool disposing )
+        {
+            if ( valueDelayer != null )
+            {
+                valueDelayer.Delayed -= DelayValue_Delayed;
+                valueDelayer = null;
+            }
+
+            base.Dispose( disposing );
+        }
+
+        private void DelayValue_Delayed( object sender, string value )
+        {
+            InvokeAsync( async () =>
+            {
+                await CurrentValueHandler( value );
+            } );
         }
 
         protected virtual Task OnChangeHandler( ChangeEventArgs e )
@@ -57,11 +85,18 @@ namespace Blazorise
         {
             if ( IsChangeTextOnKeyPress )
             {
-                var caret = await JSRunner.GetCaret( ElementRef );
+                if ( IsDelayTextOnKeyPress )
+                {
+                    valueDelayer.Update( e?.Value?.ToString() );
+                }
+                else
+                {
+                    var caret = await JSRunner.GetCaret( ElementRef );
 
-                await CurrentValueHandler( e?.Value?.ToString() );
+                    await CurrentValueHandler( e?.Value?.ToString() );
 
-                await JSRunner.SetCaret( ElementRef, caret );
+                    await JSRunner.SetCaret( ElementRef, caret );
+                }
             }
         }
 
@@ -71,6 +106,12 @@ namespace Blazorise
 
         private bool IsChangeTextOnKeyPress
             => ChangeTextOnKeyPress.GetValueOrDefault( Options?.ChangeTextOnKeyPress ?? true );
+
+        private bool IsDelayTextOnKeyPress
+            => DelayTextOnKeyPress.GetValueOrDefault( Options?.DelayTextOnKeyPress ?? false );
+
+        private int DelayTextOnKeyPressIntervalValue
+            => DelayTextOnKeyPressInterval.GetValueOrDefault( Options?.DelayTextOnKeyPressInterval ?? 300 );
 
         /// <summary>
         /// Sets the placeholder for the empty text.
@@ -109,6 +150,16 @@ namespace Blazorise
         /// Note that setting this will override global settings in <see cref="BlazoriseOptions.ChangeTextOnKeyPress"/>.
         /// </remarks>
         [Parameter] public bool? ChangeTextOnKeyPress { get; set; }
+
+        /// <summary>
+        /// If true the entered text will be slightly delayed before submiting it to the internal value.
+        /// </summary>
+        [Parameter] public bool? DelayTextOnKeyPress { get; set; }
+
+        /// <summary>
+        /// Interval in milliseconds that entered text will be delayed from submiting to the internal value.
+        /// </summary>
+        [Parameter] public int? DelayTextOnKeyPressInterval { get; set; }
 
         #endregion
     }

--- a/Source/Blazorise/BaseTextInput.razor.cs
+++ b/Source/Blazorise/BaseTextInput.razor.cs
@@ -20,7 +20,7 @@ namespace Blazorise
 
         private Color color;
 
-        private ValueDelayer valueDelayer;
+        private ValueDelayer inputValueDelayer;
 
         #endregion
 
@@ -40,8 +40,8 @@ namespace Blazorise
         {
             if ( IsDelayTextOnKeyPress )
             {
-                valueDelayer = new ValueDelayer( DelayTextOnKeyPressIntervalValue );
-                valueDelayer.Delayed += DelayValue_Delayed;
+                inputValueDelayer = new ValueDelayer( DelayTextOnKeyPressIntervalValue );
+                inputValueDelayer.Delayed += OnInputValueDelayed;
             }
 
             if ( ParentValidation != null )
@@ -54,21 +54,13 @@ namespace Blazorise
 
         protected override void Dispose( bool disposing )
         {
-            if ( valueDelayer != null )
+            if ( inputValueDelayer != null )
             {
-                valueDelayer.Delayed -= DelayValue_Delayed;
-                valueDelayer = null;
+                inputValueDelayer.Delayed -= OnInputValueDelayed;
+                inputValueDelayer = null;
             }
 
             base.Dispose( disposing );
-        }
-
-        private void DelayValue_Delayed( object sender, string value )
-        {
-            InvokeAsync( async () =>
-            {
-                await CurrentValueHandler( value );
-            } );
         }
 
         protected virtual Task OnChangeHandler( ChangeEventArgs e )
@@ -87,7 +79,7 @@ namespace Blazorise
             {
                 if ( IsDelayTextOnKeyPress )
                 {
-                    valueDelayer.Update( e?.Value?.ToString() );
+                    inputValueDelayer?.Update( e?.Value?.ToString() );
                 }
                 else
                 {
@@ -98,6 +90,14 @@ namespace Blazorise
                     await JSRunner.SetCaret( ElementRef, caret );
                 }
             }
+        }
+
+        private void OnInputValueDelayed( object sender, string value )
+        {
+            InvokeAsync( async () =>
+            {
+                await CurrentValueHandler( value );
+            } );
         }
 
         #endregion

--- a/Source/Blazorise/BlazoriseOptions.cs
+++ b/Source/Blazorise/BlazoriseOptions.cs
@@ -14,6 +14,16 @@ namespace Blazorise
         public bool ChangeTextOnKeyPress { get; set; } = true;
 
         /// <summary>
+        /// If true the entered into <see cref="TextEdit"/> will be slightly delayed before submiting it to the internal value.
+        /// </summary>
+        public bool? DelayTextOnKeyPress { get; set; } = false;
+
+        /// <summary>
+        /// Interval in milliseconds that entered text will be delayed from submiting to the <see cref="TextEdit"/> internal value.
+        /// </summary>
+        public int? DelayTextOnKeyPressInterval { get; set; } = 300;
+
+        /// <summary>
         /// If true the value in <see cref="Slider{TValue}"/> will be changed while holding and moving the slider.
         /// </summary>
         public bool ChangeSliderOnHold { get; set; } = true;

--- a/Source/Blazorise/MemoEdit.razor.cs
+++ b/Source/Blazorise/MemoEdit.razor.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using Blazorise.Utils;
 using Microsoft.AspNetCore.Components;
 #endregion
 
@@ -13,12 +14,20 @@ namespace Blazorise
     {
         #region Members
 
+        private ValueDelayer inputValueDelayer;
+
         #endregion
 
         #region Methods
 
         protected override void OnInitialized()
         {
+            if ( IsDelayTextOnKeyPress )
+            {
+                inputValueDelayer = new ValueDelayer( DelayTextOnKeyPressIntervalValue );
+                inputValueDelayer.Delayed += OnInputValueDelayed;
+            }
+
             if ( ParentValidation != null )
             {
                 ParentValidation.InitializeInputExpression( TextExpression );
@@ -49,11 +58,18 @@ namespace Blazorise
         {
             if ( IsChangeTextOnKeyPress )
             {
-                var caret = await JSRunner.GetCaret( ElementRef );
+                if ( IsDelayTextOnKeyPress )
+                {
+                    inputValueDelayer?.Update( e?.Value?.ToString() );
+                }
+                else
+                {
+                    var caret = await JSRunner.GetCaret( ElementRef );
 
-                await CurrentValueHandler( e?.Value?.ToString() );
+                    await CurrentValueHandler( e?.Value?.ToString() );
 
-                await JSRunner.SetCaret( ElementRef, caret );
+                    await JSRunner.SetCaret( ElementRef, caret );
+                }
             }
         }
 
@@ -67,6 +83,14 @@ namespace Blazorise
             return Task.FromResult( new ParseValue<string>( true, value, null ) );
         }
 
+        private void OnInputValueDelayed( object sender, string value )
+        {
+            InvokeAsync( async () =>
+            {
+                await CurrentValueHandler( value );
+            } );
+        }
+
         #endregion
 
         #region Properties
@@ -75,6 +99,12 @@ namespace Blazorise
 
         private bool IsChangeTextOnKeyPress
            => ChangeTextOnKeyPress.GetValueOrDefault( Options?.ChangeTextOnKeyPress ?? true );
+
+        private bool IsDelayTextOnKeyPress
+           => DelayTextOnKeyPress.GetValueOrDefault( Options?.DelayTextOnKeyPress ?? false );
+
+        private int DelayTextOnKeyPressIntervalValue
+            => DelayTextOnKeyPressInterval.GetValueOrDefault( Options?.DelayTextOnKeyPressInterval ?? 300 );
 
         /// <summary>
         /// Sets the placeholder for the empty text.
@@ -113,6 +143,16 @@ namespace Blazorise
         /// Note that setting this will override global settings in <see cref="BlazoriseOptions.ChangeTextOnKeyPress"/>.
         /// </remarks>
         [Parameter] public bool? ChangeTextOnKeyPress { get; set; }
+
+        /// <summary>
+        /// If true the entered text will be slightly delayed before submiting it to the internal value.
+        /// </summary>
+        [Parameter] public bool? DelayTextOnKeyPress { get; set; }
+
+        /// <summary>
+        /// Interval in milliseconds that entered text will be delayed from submiting to the internal value.
+        /// </summary>
+        [Parameter] public int? DelayTextOnKeyPressInterval { get; set; }
 
         #endregion
     }

--- a/Source/Blazorise/Utils/ValueDelayer.cs
+++ b/Source/Blazorise/Utils/ValueDelayer.cs
@@ -1,0 +1,88 @@
+﻿#region Using directives
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Timers;
+#endregion
+
+namespace Blazorise.Utils
+{
+    /// <summary>
+    /// Delays the entered value by the defined interval.
+    /// </summary>
+    public class ValueDelayer : IDisposable
+    {
+        #region Members
+
+        /// <summary>
+        /// Internal timer used to delay the value.
+        /// </summary>
+        private Timer timer;
+
+        /// <summary>
+        /// Holds the last updated value.
+        /// </summary>
+        private string value;
+
+        /// <summary>
+        /// Event raised after the interval has passed and with new updated value.
+        /// </summary>
+        public event EventHandler<string> Delayed;
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        /// <param name="interval">Interval by which the value will be delayed.</param>
+        public ValueDelayer( int interval )
+        {
+            timer = new Timer( interval );
+            timer.Elapsed += OnElapsed;
+            timer.AutoReset = false;
+        }
+
+        #endregion
+
+        #region Events
+
+        private void OnElapsed( object source, ElapsedEventArgs e )
+        {
+            Delayed?.Invoke( this, value );
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Updates the internal value.
+        /// </summary>
+        /// <param name="value">New value.</param>
+        public void Update( string value )
+        {
+            timer.Stop();
+
+            this.value = value;
+
+            timer.Start();
+        }
+
+        /// <summary>
+        /// Releases all subscribed events.
+        /// </summary>
+        public void Dispose()
+        {
+            if ( timer != null )
+            {
+                timer.Stop();
+                timer.Elapsed -= OnElapsed;
+                timer = null;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/docs/_docs/components/memo.md
+++ b/docs/_docs/components/memo.md
@@ -47,17 +47,55 @@ When using the event `TextChanged`, you also must define the `Text` value attrib
 }
 ```
 
+## Settings
+
+### Text Changed mode
+
+By default the `TextChanged` event will be raised on every keypress. To override default behavior of `TextChanged` event and to disable the change on every keypress you must set the `ChangeTextOnKeyPress` to `false` on application start. After setting it to `false` the event will be raised only after the input loses focus.
+
+```cs
+public void ConfigureServices( IServiceCollection services )
+{
+  services
+    .AddBlazorise( options =>
+    {
+      options.ChangeTextOnKeyPress = false;
+    } );
+}
+```
+
+### Text Delay mode
+
+Because of some limitations in Blazor, sometimes there can be problems when `ChangeTextOnKeyPress` is enabled. Basically if you try to type too fast into the text field the caret can jump randomly from current selection to the end of the text. To prevent that behaviour you need to enable `DelayTextOnKeyPress`. Once enabled it will slightly delay every value entered into the field to allow the Blazor engine to do it's thing. By default this option is disabled.
+
+```cs
+public void ConfigureServices( IServiceCollection services )
+{
+  services
+    .AddBlazorise( options =>
+    {
+      options.DelayTextOnKeyPress = true;
+      options.DelayTextOnKeyPressInterval = 300;
+    } );
+}
+```
+
+**Note:** All of the options above can also be defined on each `MemoEdit` individually. Defining them on `MemoEdit` will override any global settings.
+{: .notice--info}
+
 ## Attributes
 
-| Name                  | Type                                                         | Default | Description                                                                                          |
-|-----------------------|--------------------------------------------------------------|---------|------------------------------------------------------------------------------------------------------|
-| Text                  | string                                                       |         | Input value.                                                                                         |
-| TextChanged           | event                                                        |         | Occurs after text has changed.                                                                       |
-| Plaintext             | boolean                                                      | false   | Remove the default form field styling and preserve the correct margin and padding.                   |
-| ReadOnly              | boolean                                                      | false   | Prevents modification of the input’s value.                                                          |
-| Disabled              | boolean                                                      | false   | Prevents user interactions and make it appear lighter.                                               |
-| MaxLength             | int?                                                         | null    | Specifies the maximum number of characters allowed in the input element.                             |
-| Placeholder           | string                                                       |         | Sets the placeholder for the empty text.                                                             |
-| Rows                  | int?                                                         | null    | Specifies the number lines in the input element.                                                     |
-| Size                  | [Sizes]({{ "/docs/helpers/sizes/#size" | relative_url }})    | `None`  | Component size variations.                                                                           |
-| ChangeTextOnKeyPress  | bool?                                                        |  null   | If true the text in will be changed after each key press (overrides global settings).                |
+| Name                          | Type                                                         | Default | Description                                                                                          |
+|-------------------------------|--------------------------------------------------------------|---------|------------------------------------------------------------------------------------------------------|
+| Text                          | string                                                       |         | Input value.                                                                                         |
+| TextChanged                   | event                                                        |         | Occurs after text has changed.                                                                       |
+| Plaintext                     | boolean                                                      | false   | Remove the default form field styling and preserve the correct margin and padding.                   |
+| ReadOnly                      | boolean                                                      | false   | Prevents modification of the input’s value.                                                          |
+| Disabled                      | boolean                                                      | false   | Prevents user interactions and make it appear lighter.                                               |
+| MaxLength                     | `int?`                                                       | null    | Specifies the maximum number of characters allowed in the input element.                             |
+| Placeholder                   | string                                                       |         | Sets the placeholder for the empty text.                                                             |
+| Rows                          | `int?`                                                       | null    | Specifies the number lines in the input element.                                                     |
+| Size                          | [Sizes]({{ "/docs/helpers/sizes/#size" | relative_url }})    | `None`  | Component size variations.                                                                           |
+| ChangeTextOnKeyPress          | `bool?`                                                      |  null   | If true the text in will be changed after each key press (overrides global settings).                |
+| DelayTextOnKeyPress           | `bool?`                                                      |  null   | If true the entered text will be slightly delayed before submitting it to the internal value.        |
+| DelayTextOnKeyPressInterval   | `int?`                                                       |  null   | Interval in milliseconds that entered text will be delayed from submitting to the internal value.    |

--- a/docs/_docs/components/text.md
+++ b/docs/_docs/components/text.md
@@ -133,9 +133,9 @@ When using the event `TextChanged`, you also must define the `Text` value attrib
 
 ## Settings
 
-### TextChanged mode
+### Text Changed mode
 
-By default the TextChanged event will be raised on every keypress. To override default behavior of `TextChanged` event and to disable the change on every keypress you must set the `ChangeTextOnKeyPress` to `false` on application start. After setting it to `false` the event will be raised only after the input loses focus.
+By default the `TextChanged` event will be raised on every keypress. To override default behavior of `TextChanged` event and to disable the change on every keypress you must set the `ChangeTextOnKeyPress` to `false` on application start. After setting it to `false` the event will be raised only after the input loses focus.
 
 ```cs
 public void ConfigureServices( IServiceCollection services )
@@ -148,22 +148,43 @@ public void ConfigureServices( IServiceCollection services )
 }
 ```
 
+### Text Delay mode
+
+Because of some limitations in Blazor, sometimes there can be problems when `ChangeTextOnKeyPress` is enabled. Basically if you try to type too fast into the text field the caret can jump randomly from current selection to the end of the text. To prevent that behaviour you need to enable `DelayTextOnKeyPress`. Once enabled it will slightly delay every value entered into the field to allow the Blazor engine to do it's thing. By default this option is disabled.
+
+```cs
+public void ConfigureServices( IServiceCollection services )
+{
+  services
+    .AddBlazorise( options =>
+    {
+      options.DelayTextOnKeyPress = true;
+      options.DelayTextOnKeyPressInterval = 300;
+    } );
+}
+```
+
+**Note:** All of the options above can also be defined on each `TextEdit` individually. Defining them on `TextEdit` will override any global settings.
+{: .notice--info}
+
 ## Attributes
 
-| Name                  | Type                                                                | Default | Description                                                                                          |
-|-----------------------|---------------------------------------------------------------------|---------|------------------------------------------------------------------------------------------------------|
-| Role                  | TextRole                                                            | `Text`  | The role of the input text.                                                                          |
-| Text                  | string                                                              |         | Input value.                                                                                         |
-| TextChanged           | event                                                               |         | Occurs after text has changed.                                                                       |
-| Plaintext             | boolean                                                             | false   | Remove the default form field styling and preserve the correct margin and padding.                   |
-| ReadOnly              | boolean                                                             | false   | Prevents modification of the input’s value.                                                          |
-| Disabled              | boolean                                                             | false   | Prevents user interactions and make it appear lighter.                                               |
-| MaxLength             | int?                                                                | null    | Specifies the maximum number of characters allowed in the input element.                             |
-| Placeholder           | string                                                              |         | Sets the placeholder for the empty text.                                                             |
-| Pattern               | string                                                              |         | Specifies a regular expression that the input element's value is checked against on form validation. |
-| Color                 | [Colors]({{ "/docs/helpers/colors/#color" | relative_url }})        | `None`  | Component visual or contextual style variants.                                                       |
-| Size                  | [Sizes]({{ "/docs/helpers/sizes/#size" | relative_url }})           | `None`  | Component size variations.                                                                           |
-| EditMask              | string                                                              |         | A string representing a edit mask expression.                                                        |
-| MaskType              | [MaskType]({{ "/docs/helpers/enums/#masktype" | relative_url }})    | `None`  | Specify the mask type used by the editor.                                                            |
-| VisibleCharacters     | int?                                                                |  null   | Specifies the visible width, in characters, of an `<input>` element.                                 |
-| ChangeTextOnKeyPress  | bool?                                                               |  null   | If true the text in will be changed after each key press (overrides global settings).                |
+| Name                          | Type                                                                | Default | Description                                                                                          |
+|-------------------------------|---------------------------------------------------------------------|---------|------------------------------------------------------------------------------------------------------|
+| Role                          | TextRole                                                            | `Text`  | The role of the input text.                                                                          |
+| Text                          | string                                                              |         | Input value.                                                                                         |
+| TextChanged                   | event                                                               |         | Occurs after text has changed.                                                                       |
+| Plaintext                     | boolean                                                             | false   | Remove the default form field styling and preserve the correct margin and padding.                   |
+| ReadOnly                      | boolean                                                             | false   | Prevents modification of the input’s value.                                                          |
+| Disabled                      | boolean                                                             | false   | Prevents user interactions and make it appear lighter.                                               |
+| MaxLength                     | `int?`                                                              | null    | Specifies the maximum number of characters allowed in the input element.                             |
+| Placeholder                   | string                                                              |         | Sets the placeholder for the empty text.                                                             |
+| Pattern                       | string                                                              |         | Specifies a regular expression that the input element's value is checked against on form validation. |
+| Color                         | [Colors]({{ "/docs/helpers/colors/#color" | relative_url }})        | `None`  | Component visual or contextual style variants.                                                       |
+| Size                          | [Sizes]({{ "/docs/helpers/sizes/#size" | relative_url }})           | `None`  | Component size variations.                                                                           |
+| EditMask                      | string                                                              |         | A string representing a edit mask expression.                                                        |
+| MaskType                      | [MaskType]({{ "/docs/helpers/enums/#masktype" | relative_url }})    | `None`  | Specify the mask type used by the editor.                                                            |
+| VisibleCharacters             | `int?`                                                              |  null   | Specifies the visible width, in characters, of an `<input>` element.                                 |
+| ChangeTextOnKeyPress          | `bool?`                                                             |  null   | If true the text in will be changed after each key press (overrides global settings).                |
+| DelayTextOnKeyPress           | `bool?`                                                             |  null   | If true the entered text will be slightly delayed before submitting it to the internal value.        |
+| DelayTextOnKeyPressInterval   | `int?`                                                              |  null   | Interval in milliseconds that entered text will be delayed from submitting to the internal value.    |


### PR DESCRIPTION
#1053 TextEdit jump caret to the end of the text for every typed char, when ChangeTextOnKeyPress is true

- Added `DelayTextOnKeyPress` and `DelayTextOnKeyPressInterval` to global options
- Override of `DelayTextOnKeyPress` and `DelayTextOnKeyPressInterval` added to TextEdit and MemoEdit
- With the  `DelayTextOnKeyPress` enabled every value entered into text field will be slightly delayed
- Updated docs