### PR TITLE
Fixed display format of non editable field in datagrid inline mode

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor
@@ -97,7 +97,7 @@ else if ( EditMode == DataGridEditMode.Inline )
                         }
                         else
                         {
-                            @column.GetValue( Item )
+                            @column.FormatDisplayValue( Item )
                         }
                     }
                 </TableRowCell>


### PR DESCRIPTION
#1203 In DataGrid DisplayFormat disappears when Editing Inline