### PR TITLE
Added Reset method to FileEdit

### DIFF
--- a/Source/Blazorise/FileEdit.razor.cs
+++ b/Source/Blazorise/FileEdit.razor.cs
@@ -263,7 +263,7 @@ namespace Blazorise
         [Parameter] public EventCallback<FileProgressedEventArgs> Progressed { get; set; }
 
         /// <summary>
-        /// If true file input will be automatically reseted after it has being uploaded.
+        /// If true file input will be automatically reset after it has being uploaded.
         /// </summary>
         [Parameter] public bool AutoReset { get; set; } = true;
 

--- a/Source/Blazorise/FileEdit.razor.cs
+++ b/Source/Blazorise/FileEdit.razor.cs
@@ -19,6 +19,9 @@ namespace Blazorise
         Task NotifyChange( FileEntry[] files );
     }
 
+    /// <summary>
+    /// Input component with support for single of multi file upload.
+    /// </summary>
     public partial class FileEdit : BaseInputComponent<IFileEntry[]>, IFileEdit
     {
         #region Members
@@ -34,6 +37,7 @@ namespace Blazorise
 
         #region Methods
 
+        /// <inheritdoc/>
         protected override void BuildClasses( ClassBuilder builder )
         {
             builder.Append( ClassProvider.FileEdit() );
@@ -42,6 +46,7 @@ namespace Blazorise
             base.BuildClasses( builder );
         }
 
+        /// <inheritdoc/>
         protected override async Task OnFirstAfterRenderAsync()
         {
             dotNetObjectRef ??= JSRunner.CreateDotNetObjectRef( new FileEditAdapter( this ) );
@@ -51,6 +56,7 @@ namespace Blazorise
             await base.OnFirstAfterRenderAsync();
         }
 
+        /// <inheritdoc/>
         protected override void Dispose( bool disposing )
         {
             if ( disposing && Rendered )
@@ -62,6 +68,11 @@ namespace Blazorise
             base.Dispose( disposing );
         }
 
+        /// <summary>
+        /// Notifies the component that file input value has changed.
+        /// </summary>
+        /// <param name="files">List of changed file(s).</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
         public async Task NotifyChange( FileEntry[] files )
         {
             // Unlike in other Edit components we cannot just call CurrentValueHandler since
@@ -86,16 +97,23 @@ namespace Blazorise
             await InvokeAsync( () => StateHasChanged() );
         }
 
+        /// <inheritdoc/>
         protected override Task OnInternalValueChanged( IFileEntry[] value )
         {
             throw new NotImplementedException( $"{nameof( OnInternalValueChanged )} in {nameof( FileEdit )} should never be called." );
         }
 
+        /// <inheritdoc/>
         protected override Task<ParseValue<IFileEntry[]>> ParseValueFromStringAsync( string value )
         {
             throw new NotImplementedException( $"{nameof( ParseValueFromStringAsync )} in {nameof( FileEdit )} should never be called." );
         }
 
+        /// <summary>
+        /// Notifies the component that file upload is about to start.
+        /// </summary>
+        /// <param name="fileEntry">File entry to be uploaded.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
         internal Task UpdateFileStartedAsync( IFileEntry fileEntry )
         {
             // reset all
@@ -106,16 +124,40 @@ namespace Blazorise
             return Started.InvokeAsync( new FileStartedEventArgs( fileEntry ) );
         }
 
-        internal Task UpdateFileEndedAsync( IFileEntry fileEntry, bool success )
+        /// <summary>
+        /// Notifies the component that file upload has ended.
+        /// </summary>
+        /// <param name="fileEntry">Uploaded file entry.</param>
+        /// <param name="success">True if the file upload was successful.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        internal async Task UpdateFileEndedAsync( IFileEntry fileEntry, bool success )
         {
-            return Ended.InvokeAsync( new FileEndedEventArgs( fileEntry, success ) );
+            if ( AutoReset )
+            {
+                await Reset();
+            }
+
+            await Ended.InvokeAsync( new FileEndedEventArgs( fileEntry, success ) );
         }
 
+        /// <summary>
+        /// Updates component with the latest file data.
+        /// </summary>
+        /// <param name="fileEntry">Currently processed file entry.</param>
+        /// <param name="position">The current position of this stream.</param>
+        /// <param name="data">Curerntly read data.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
         internal Task UpdateFileWrittenAsync( IFileEntry fileEntry, long position, byte[] data )
         {
             return Written.InvokeAsync( new FileWrittenEventArgs( fileEntry, position, data ) );
         }
 
+        /// <summary>
+        /// Updated the component with the latest upload progress.
+        /// </summary>
+        /// <param name="fileEntry">Currently processed file entry.</param>
+        /// <param name="progressProgress">Progress value.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
         internal async Task UpdateFileProgressAsync( IFileEntry fileEntry, long progressProgress )
         {
             ProgressProgress += progressProgress;
@@ -130,16 +172,32 @@ namespace Blazorise
             }
         }
 
+        /// <summary>
+        /// Writes the file data to the target stream.
+        /// </summary>
+        /// <param name="fileEntry">Currently processed file entry.</param>
+        /// <param name="stream">Target stream.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
         internal async Task WriteToStreamAsync( FileEntry fileEntry, Stream stream )
         {
             await new RemoteFileEntryStreamReader( JSRunner, ElementRef, fileEntry, this, MaxMessageSize )
                 .WriteToStreamAsync( stream, CancellationToken.None );
         }
 
+        /// <summary>
+        /// Manaully resets the input file value.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        public async Task Reset()
+        {
+            await JSRunner.ResetFileEdit( ElementRef, ElementId );
+        }
+
         #endregion
 
         #region Properties
 
+        /// <inheritdoc/>
         protected override IFileEntry[] InternalValue { get => files; set => files = value; }
 
         protected long ProgressProgress;
@@ -203,6 +261,11 @@ namespace Blazorise
         /// Notifies the progress of file being written to the destination stream.
         /// </summary>
         [Parameter] public EventCallback<FileProgressedEventArgs> Progressed { get; set; }
+
+        /// <summary>
+        /// If true file input will be automatically reseted after it has being uploaded.
+        /// </summary>
+        [Parameter] public bool AutoReset { get; set; } = true;
 
         #endregion
     }

--- a/Source/Blazorise/IJSRunner.cs
+++ b/Source/Blazorise/IJSRunner.cs
@@ -86,5 +86,7 @@ namespace Blazorise
         ValueTask<bool> DestroyFileEdit( ElementReference elementRef, string elementId );
 
         ValueTask<string> ReadDataAsync( CancellationToken cancellationToken, ElementReference elementRef, int fileEntryId, long position, long length );
+
+        ValueTask ResetFileEdit( ElementReference elementRef, string elementId );
     }
 }

--- a/Source/Blazorise/JSRunner.cs
+++ b/Source/Blazorise/JSRunner.cs
@@ -235,5 +235,10 @@ namespace Blazorise
         {
             return runtime.InvokeAsync<string>( $"{BLAZORISE_NAMESPACE}.fileEdit.readFileData", cancellationToken, elementRef, fileEntryId, position, length );
         }
+
+        public ValueTask ResetFileEdit( ElementReference elementRef, string elementId )
+        {
+            return runtime.InvokeVoidAsync( $"{BLAZORISE_NAMESPACE}.fileEdit.reset", elementRef, elementId );
+        }
     }
 }

--- a/Source/Blazorise/wwwroot/blazorise.js
+++ b/Source/Blazorise/wwwroot/blazorise.js
@@ -465,6 +465,14 @@ window.blazorise = {
             return true;
         },
 
+        reset: (element, elementId) => {
+            if (element) {
+                element.value = '';
+            }
+
+            return true;
+        },
+
         readFileData: function readFileData(element, fileEntryId, position, length) {
             var readPromise = getArrayBufferFromFileAsync(element, fileEntryId);
 

--- a/docs/_docs/components/file.md
+++ b/docs/_docs/components/file.md
@@ -124,6 +124,23 @@ In this example you can see the usage of all events, including the `Written` and
 }
 ```
 
+### Reset
+
+By default after each file upload has finished, file input will automatically reset to it's initial state. If you want this behavior disabled and control it manually you need to first set `AutoReset` to `false`. After that you can call `Reset()` every time you want the file input to be reset.
+
+```cs
+<FileEdit @ref="@fileEdit" AutoReset="false" ... />
+
+@code{
+    FileEdit fileEdit;
+
+    Task OnSomeButtonClick()
+    {
+        return fileEdit.Reset();
+    }
+}
+```
+
 ## Attributes
 
 | Name                  | Type      | Default     | Description                                                                                  |
@@ -136,3 +153,4 @@ In this example you can see the usage of all events, including the `Written` and
 | Progressed            | event     |             | Notifies the progress of file being uploaded.                                                |
 | Started               | event     |             | Occurs when an individual file upload has started.                                           |
 | Ended                 | event     |             | Occurs when an individual file upload has ended.                                             |
+| AutoReset             | boolean   | true        | If true file input will be automatically reset after it has being uploaded.                  |


### PR DESCRIPTION
#1177 Add Reset() method to FileEdit

- `FileEdit `will automatically reset after each upload if `AutoReset` is enabled
- Added new `Reset()` method for manual operation