### PR TITLE
Added support for DateTimeOffset conversions

### DIFF
--- a/Source/Blazorise/Utils/Converters.cs
+++ b/Source/Blazorise/Utils/Converters.cs
@@ -103,6 +103,8 @@ namespace Blazorise.Utils
                     result = theEnum;
                 else if ( conversionType == typeof( Guid ) )
                     result = (TValue)Convert.ChangeType( Guid.Parse( value.ToString() ), conversionType );
+                else if ( conversionType == typeof( DateTimeOffset ) )
+                    result = (TValue)Convert.ChangeType( DateTimeOffset.Parse( value.ToString() ), conversionType );
                 else
                     result = (TValue)Convert.ChangeType( value, conversionType, cultureInfo ?? CultureInfo.InvariantCulture );
 

--- a/Tests/Blazorise.Tests/Utils/ConvertersTests.cs
+++ b/Tests/Blazorise.Tests/Utils/ConvertersTests.cs
@@ -121,7 +121,7 @@ namespace Blazorise.Tests.Utils
         [Theory]
         [InlineData( "2020-08-24T17:48:00-04:00", true )]
         [InlineData( "not a date", false )]
-        public void TryChangeType_With_DateTimeOffsetAsString_Should_Succeed( string value, bool expected )
+        public void TryChangeType_With_DateTimeOffset_String_As_Value_Should_BeExpected( string value, bool expected )
         {
             // Arrange
 

--- a/Tests/Blazorise.Tests/Utils/ConvertersTests.cs
+++ b/Tests/Blazorise.Tests/Utils/ConvertersTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Serialization;
+﻿using System;
+using System.Runtime.Serialization;
 using Blazorise.Utils;
 using Xunit;
 
@@ -115,6 +116,20 @@ namespace Blazorise.Tests.Utils
             Assert.NotNull( result );
             Assert.Equal( 1, result.Count );
             Assert.Equal( "abc", result["Foo"] );
+        }
+
+        [Theory]
+        [InlineData( "2020-08-24T17:48:00-04:00", true )]
+        [InlineData( "not a date", false )]
+        public void TryChangeType_With_DateTimeOffsetAsString_Should_Succeed( string value, bool expected )
+        {
+            // Arrange
+
+            // Act
+            var result = Converters.TryChangeType<DateTimeOffset>( value, out var _ );
+
+            // Assert
+            Assert.Equal( expected, result );
         }
     }
 


### PR DESCRIPTION
We experienced an issue with a Select component being bound to DateTimeOffset and the Convert.ChangeType not supporting it natively, much like Guid. So, I added DateTimeOffset support like the Guid type.