### PR TITLE
Update Slider value when dragged by mouse

### DIFF
--- a/Source/Blazorise/Slider.razor
+++ b/Source/Blazorise/Slider.razor
@@ -2,7 +2,7 @@
 @inherits Blazorise.BaseInputComponent<TValue>
 @if ( !HasCustomRegistration )
 {
-    <input type="range" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" step="@Step" min="@Min" max="@Max" value="@CurrentValueAsString" @onchange="@OnChangeHandler" @onfocus="@OnFocus" @onfocusin="@FocusIn" @onfocusout="@FocusOut" @attributes="@Attributes">
+    <input type="range" class="@ClassNames" style="@StyleNames" disabled="@Disabled" readonly="@ReadOnly" step="@Step" min="@Min" max="@Max" value="@CurrentValueAsString" @onchange="@OnChangeHandler" @oninput="@OnChangeHandler" @onfocus="@OnFocus" @onfocusin="@FocusIn" @onfocusout="@FocusOut" @attributes="@Attributes">
     @ChildContent
     @Feedback
 }


### PR DESCRIPTION
The slide currently doesn't update directly when it's dragged around by the mouse.
It's only updated when the drag stops / mouse button signals up.

To caputure mouse input directly, the `oninput` needs to be handled as well (see stackoverflow: [onchange event on input type=range is not triggering in firefox while dragging](https://stackoverflow.com/a/19067260/2132796)).