### PR TITLE
Added StatusChanged event to Validation component

### DIFF
--- a/Source/Blazorise/Validation.razor.cs
+++ b/Source/Blazorise/Validation.razor.cs
@@ -181,10 +181,16 @@ namespace Blazorise
 
                 EditContext.ValidateField( messages, fieldIdentifier );
 
-                Status = messages[fieldIdentifier].Any() ? ValidationStatus.Error : ValidationStatus.Success;
-                LastErrorMessage = Status == ValidationStatus.Error ? string.Join( "; ", messages[fieldIdentifier] ) : null;
+                var matchStatus = messages[fieldIdentifier].Any() ? ValidationStatus.Error : ValidationStatus.Success;
 
-                NotifyValidationStatusChanged( Status, LastErrorMessage );
+                if ( Status != matchStatus )
+                {
+                    Status = matchStatus;
+
+                    LastErrorMessage = Status == ValidationStatus.Error ? string.Join( "; ", messages[fieldIdentifier] ) : null;
+
+                    NotifyValidationStatusChanged( Status, LastErrorMessage );
+                }
             }
             else
             {
@@ -223,6 +229,7 @@ namespace Blazorise
         private void NotifyValidationStatusChanged( ValidationStatus status, string message = null )
         {
             ValidationStatusChanged?.Invoke( this, new ValidationStatusChangedEventArgs( status, message ) );
+            StatusChanged.InvokeAsync( status );
 
             ParentValidations?.NotifyValidationStatusChanged( this );
         }
@@ -245,6 +252,11 @@ namespace Blazorise
         /// Gets or sets the current validation status.
         /// </summary>
         [Parameter] public ValidationStatus Status { get; set; }
+
+        /// <summary>
+        /// Occurs each time that validation status changed.
+        /// </summary>
+        [Parameter] public EventCallback<ValidationStatus> StatusChanged { get; set; }
 
         /// <summary>
         /// Gets the last error message.

--- a/docs/_docs/components/validation.md
+++ b/docs/_docs/components/validation.md
@@ -264,8 +264,9 @@ Here is a list of the validators currently available.
 
 ### Validation
 
-| Name         | Type                                                                              | Default  | Description                                                                                |
-|--------------|-----------------------------------------------------------------------------------|----------|--------------------------------------------------------------------------------------------|
-| Status       | [ValidationStatus]({{ "/docs/helpers/enums/#validationstatus" | relative_url }})  | `None`   | Gets or sets the current validation status.                                                |
-| Validator    | action                                                                            |          | Validates the input value after it has being changed.                                      |
-| UsePattern   | boolean                                                                           | false    | Forces validation to use regex pattern matching instead of default validator handler.      |
+| Name          | Type                                                                              | Default  | Description                                                                                |
+|---------------|-----------------------------------------------------------------------------------|----------|--------------------------------------------------------------------------------------------|
+| Status        | [ValidationStatus]({{ "/docs/helpers/enums/#validationstatus" | relative_url }})  | `None`   | Gets or sets the current validation status.                                                |
+| StatusChanged | EventCallback                                                                     |          | Event is fired whenever there is a change in validation status.                            |
+| Validator     | action                                                                            |          | Validates the input value after it has being changed.                                      |
+| UsePattern    | boolean                                                                           | false    | Forces validation to use regex pattern matching instead of default validator handler.      |


### PR DESCRIPTION
#1329 

Done:
- Added `StatusChanged` event to `Validation` component
- Fixes bug with model validation calling notification multiple times

Usage:

```cshtml
<Validation Validator="@ValidationRule.IsNotEmpty" @bind-Status="@nameStatus">
    <Field Horizontal="true">
        <FieldLabel ColumnSize="ColumnSize.Is2">
            Full Name
            @if ( nameStatus != ValidationStatus.Error )
            {
                <span style="color:red;">*</span>
            }
        </FieldLabel>
        <FieldBody ColumnSize="ColumnSize.Is10">
            <TextEdit Placeholder="First and last name">
                <Feedback>
                    <ValidationError>Enter full name!</ValidationError>
                </Feedback>
            </TextEdit>
        </FieldBody>
    </Field>
</Validation>
```