### PR TITLE
fix 1280 - bad author names in nuget package

### DIFF
--- a/Source/Extensions/Blazorise.RichTextEdit/Blazorise.RichTextEdit.csproj
+++ b/Source/Extensions/Blazorise.RichTextEdit/Blazorise.RichTextEdit.csproj
@@ -9,7 +9,7 @@
     <PackageProjectUrl>https://blazorise.com/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/stsrki/Blazorise</RepositoryUrl>
     <PackageTags>blazorise blazor components rtf richtextedit</PackageTags>
-    <Authors>%Authors%;Niek Jannink</Authors>
+    <Authors>$(Authors);Niek Jannink</Authors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Extensions/Blazorise.TreeView/Blazorise.TreeView.csproj
+++ b/Source/Extensions/Blazorise.TreeView/Blazorise.TreeView.csproj
@@ -9,7 +9,7 @@
     <PackageProjectUrl>https://blazorise.com/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/stsrki/Blazorise</RepositoryUrl>
     <PackageTags>blazorise blazor components treeview</PackageTags>
-    <Authors>%Authors%;Robin Clark</Authors>
+    <Authors>$(Authors);Robin Clark</Authors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix nuget author names

Issue: [1280](https://github.com/stsrki/Blazorise/issues/1280)