### PR TITLE
Add model to EditTemplate context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -244,3 +244,4 @@ ModelManifest.xml
 # jekyll
 _site
 Gemfile.lock
+*.dt

--- a/.gitignore
+++ b/.gitignore
@@ -244,4 +244,3 @@ ModelManifest.xml
 # jekyll
 _site
 Gemfile.lock
-*.dt

--- a/Source/Extensions/Blazorise.DataGrid/CellEditContext.cs
+++ b/Source/Extensions/Blazorise.DataGrid/CellEditContext.cs
@@ -14,5 +14,11 @@ namespace Blazorise.DataGrid
         /// Gets or sets the editor value.
         /// </summary>
         public object CellValue { get; set; }
+
+        /// <summary>
+        /// Gets or sets the parent model of the edited CellValue - to be used in decision making
+        /// TODO: Check if init would not be better than set
+        /// </summary>
+        public object Model { get; set; }
     }
 }

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -186,7 +186,7 @@ namespace Blazorise.DataGrid
 
         protected void OnNewCommand()
         {
-            var newItem = CreateNewItem();
+            TItem newItem = NewItemFactory != null ? NewItemFactory.Invoke() : CreateNewItem();
 
             NewItemDefaultSetter?.Invoke( newItem );
 
@@ -958,6 +958,11 @@ namespace Blazorise.DataGrid
         /// Function, that is called, when a new item is created for inserting new entry.
         /// </summary>
         [Parameter] public Action<TItem> NewItemDefaultSetter { get; set; }
+
+        /// <summary>
+        /// Function that, if set, is called to create new instance of an item. If left null a default constructor will be used.
+        /// </summary>
+        [Parameter] public Func<TItem> NewItemFactory { get; set; }
 
         /// <summary>
         /// Adds stripes to the table.

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -186,7 +186,7 @@ namespace Blazorise.DataGrid
 
         protected void OnNewCommand()
         {
-            TItem newItem = NewItemFactory != null ? NewItemFactory.Invoke() : CreateNewItem();
+            var newItem = CreateNewItem();
 
             NewItemDefaultSetter?.Invoke( newItem );
 
@@ -958,11 +958,6 @@ namespace Blazorise.DataGrid
         /// Function, that is called, when a new item is created for inserting new entry.
         /// </summary>
         [Parameter] public Action<TItem> NewItemDefaultSetter { get; set; }
-
-        /// <summary>
-        /// Function that, if set, is called to create new instance of an item. If left null a default constructor will be used.
-        /// </summary>
-        [Parameter] public Func<TItem> NewItemFactory { get; set; }
 
         /// <summary>
         /// Adds stripes to the table.

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -164,6 +164,7 @@ namespace Blazorise.DataGrid
                 editItemCellValues.Add( column.ElementId, new CellEditContext
                 {
                     CellValue = column.GetValue( editItem ),
+                    Model = editItem
                 } );
             }
         }


### PR DESCRIPTION
- This commit adds model to edit template and sets it in InitEditItem inside of DataGrid.razor.cs file. This allows access to parent model of the edited value.

- Related to issue #852