### PR TITLE
Adds a public Validate() methods

### DIFF
--- a/Source/Blazorise/Validation.razor.cs
+++ b/Source/Blazorise/Validation.razor.cs
@@ -191,6 +191,14 @@ namespace Blazorise
         }
 
         /// <summary>
+        /// Runs the validation process based on the last available value.
+        /// </summary>
+        public ValidationStatus Validate()
+        {
+            return Validate( inputComponent.ValidationValue );
+        }
+
+        /// <summary>
         /// Runs the validation process.
         /// </summary>
         /// <param name="newValidationValue">New validation value.</param>


### PR DESCRIPTION
resolve #1495 0.9.2 Breaking Change: Validation.Validate() now requires a parameter