### PR TITLE
RichTextEdit - Add missing link action

### DIFF
--- a/Source/Extensions/Blazorise.RichTextEdit/Enums.cs
+++ b/Source/Extensions/Blazorise.RichTextEdit/Enums.cs
@@ -22,7 +22,8 @@
         Background,
         Font,
         Align,
-        Clean
+        Clean,
+        Link
     }
 
     /// <summary>

--- a/Source/Extensions/Blazorise.RichTextEdit/Providers/RichTextEditActionClassProvider.cs
+++ b/Source/Extensions/Blazorise.RichTextEdit/Providers/RichTextEditActionClassProvider.cs
@@ -28,6 +28,7 @@
                 RichTextEditAction.Font => "ql-font",
                 RichTextEditAction.Align => "ql-align",
                 RichTextEditAction.Clean => "ql-clean",
+                RichTextEditAction.Link => "ql-link",
                 null => "",
                 _ => $"ql-{action.ToString().ToLower()}"
             };


### PR DESCRIPTION
One of the button actions was missing for creating [links](https://quilljs.com/docs/quickstart/)