### PR TITLE
RTE - Fix for issue 1414 - Server hosted gives js errors

### DIFF
--- a/Source/Extensions/Blazorise.RichTextEdit/wwwroot/blazorise.richtextedit.js
+++ b/Source/Extensions/Blazorise.RichTextEdit/wwwroot/blazorise.richtextedit.js
@@ -46,7 +46,7 @@
         quill.on('text-change',
             (_dx, _dy, source) => {
                 if (source === 'user') {
-                    dotnetAdapter.invokeMethod(onContentChanged);
+                    dotnetAdapter.invokeMethodAsync(onContentChanged);
                 }
             });
         editorRef.quill = quill;


### PR DESCRIPTION
Resolve [1414](https://github.com/stsrki/Blazorise/issues/1414#issuecomment-732977799).

Did some quick testing of both the wasm as server hosted version of RTE and both seem to work fine with this fix.