### PR TITLE
DataGrid: EmptyCellTemplate

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
@@ -234,6 +234,9 @@
                             @("Create Employee")
                         }
                     </PopupTitleTemplate>
+                    <EmptyCellTemplate>
+                        <Text Style="opacity: .5;">--</Text>
+                    </EmptyCellTemplate>
                 </DataGrid>
             </CardBody>
         </Card>

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -887,6 +887,11 @@ namespace Blazorise.DataGrid
         /// Gets or sets content of table body for empty DisplayData.
         /// </summary>
         [Parameter] public RenderFragment EmptyTemplate { get; set; }
+        
+        /// <summary>
+        /// Gets or sets content of cell body for empty DisplayData.
+        /// </summary>
+        [Parameter] public RenderFragment EmptyCellTemplate { get; set; }
 
         /// <summary>
         /// Gets or sets content of table body for handle ReadData.

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -891,7 +891,7 @@ namespace Blazorise.DataGrid
         /// <summary>
         /// Gets or sets content of cell body for empty DisplayData.
         /// </summary>
-        [Parameter] public RenderFragment EmptyCellTemplate { get; set; }
+        [Parameter] public RenderFragment<TItem> EmptyCellTemplate { get; set; }
 
         /// <summary>
         /// Gets or sets content of table body for handle ReadData.

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -887,7 +887,7 @@ namespace Blazorise.DataGrid
         /// Gets or sets content of table body for empty DisplayData.
         /// </summary>
         [Parameter] public RenderFragment EmptyTemplate { get; set; }
-        
+
         /// <summary>
         /// Gets or sets content of cell body for empty DisplayData.
         /// </summary>

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor
@@ -43,7 +43,7 @@
                     {
                         @column.DisplayTemplate( Item )
                     }
-                    else if (ParentDataGrid.EmptyCellTemplate != null && column.GetValue(Item) == null)
+                    else if ( ParentDataGrid.EmptyCellTemplate != null && column.GetValue( Item ) == null )
                     {
                         @ParentDataGrid.EmptyCellTemplate
                     }

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor
@@ -45,7 +45,7 @@
                     }
                     else if ( ParentDataGrid.EmptyCellTemplate != null && column.GetValue( Item ) == null )
                     {
-                        @ParentDataGrid.EmptyCellTemplate
+                        @ParentDataGrid.EmptyCellTemplate( Item )
                     }
                     else
                     {

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRow.razor
@@ -43,6 +43,10 @@
                     {
                         @column.DisplayTemplate( Item )
                     }
+                    else if (ParentDataGrid.EmptyCellTemplate != null && column.GetValue(Item) == null)
+                    {
+                        @ParentDataGrid.EmptyCellTemplate
+                    }
                     else
                     {
                         @column.FormatDisplayValue( Item )

--- a/docs/_docs/extensions/datagrid.md
+++ b/docs/_docs/extensions/datagrid.md
@@ -544,9 +544,7 @@ If you want to change display of content, while grid is empty or `ReadData` is e
 
 ### Empty Cell Template
 
-If you want to change display of content, if a cell's value is null.
-
-- `EmptyCellTemplate`
+If you want to change cell content display when cell's value is null, use `EmptyCellTemplate`.
 
 ```html
 <DataGrid TItem="Employee"
@@ -562,23 +560,6 @@ If you want to change display of content, if a cell's value is null.
 </DataGrid>
 ```
 
-```cs
-@code
-{
-    Employee[] employeeList;
-    int totalEmployees;
-
-    async Task LoadEmployeesFromService( DataGridReadDataEventArgs<Employee> e )
-    {
-        /*
-        * This can be call to anything like calling api for load employees
-        * and while execution 'LoadingTemplate' will be displayed.
-        * If your api call returns empty result, then 'EmptyTemplate' will be displayed,
-        * so that you can see easily, that your loading is finish, but your result is empty.
-        */
-    }
-}
-```
 ### DataGrid Multiple Selection
 
 Set `SelectionMode` to `DataGridSelectionMode.Multiple` to enable multiple selection on Datagrid. 

--- a/docs/_docs/extensions/datagrid.md
+++ b/docs/_docs/extensions/datagrid.md
@@ -540,6 +540,45 @@ If you want to change display of content, while grid is empty or `ReadData` is e
     }
 }
 ```
+
+
+### Empty Cell Template
+
+If you want to change display of content, if a cell's value is null.
+
+- `EmptyCellTemplate`
+
+```html
+<DataGrid TItem="Employee"
+    Data="@employeeList"
+    TotalItems="@totalEmployees"
+    ReadData="@LoadEmployeesFromService">
+    <ChildContent>
+    	<!--DataGridColumns-->
+    </ChildContent>
+    <EmptyCellTemplate>
+    	<Text Style="opacity: .5;">-</Text>
+    </EmptyTemplate>
+</DataGrid>
+```
+
+```cs
+@code
+{
+    Employee[] employeeList;
+    int totalEmployees;
+
+    async Task LoadEmployeesFromService( DataGridReadDataEventArgs<Employee> e )
+    {
+        /*
+        * This can be call to anything like calling api for load employees
+        * and while execution 'LoadingTemplate' will be displayed.
+        * If your api call returns empty result, then 'EmptyTemplate' will be displayed,
+        * so that you can see easily, that your loading is finish, but your result is empty.
+        */
+    }
+}
+```
 ### DataGrid Multiple Selection
 
 Set `SelectionMode` to `DataGridSelectionMode.Multiple` to enable multiple selection on Datagrid. 
@@ -601,6 +640,7 @@ Optionally you can use the new Datagrid column `<DataGridMultiSelectColumn>` to 
 | RowRemoving            | Action                                                              |         | Cancelable event called before the row is removed.                                                          |
 | RowRemoved             | EventCallback                                                       |         | Event called after the row is removed.                                                                      |
 | PageChanged            | EventCallback                                                       |         | Occurs after the selected page has changed.                                                                 |
+| EmptyCellTemplate      | RenderingFragment                                                   |         | Define the format for empty data cell                                                                 |
 | EmptyTemplate          | RenderingFragment                                                   |         | Define the format for empty data collection                                                                 |
 | LoadingTemplate        | RenderingFragment                                                   |         | Define the format for signal of loading data                                                                |
 | PopupTitleTemplate     | `RenderFragment<PopupTitleContext<TItem>>`                          |         | Template for custom title of edit popup dialog                                                              |


### PR DESCRIPTION
- Implemented EmptyCellTemplate to allow customization of all cells that are null. Updated the docs and added an EmptyCellTemplate to Datagrid Demo.
- EmptyCellTemplate is only applied if DisplayTemplate is not defined for that column.

