### PR TITLE
Fixed CellsEditableOn for popup edit mode.

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
@@ -124,6 +124,13 @@ namespace Blazorise.DataGrid
             return FormatDisplayValue( GetValue( item ) );
         }
 
+        public bool CellValuesAreEditable()
+        {
+            return Editable &&
+                ( ( CellsEditableOnNewCommand && ParentDataGrid?.EditState == DataGridEditState.New )
+                || ( CellsEditableOnEditCommand && ParentDataGrid?.EditState == DataGridEditState.Edit ) );
+        }
+
         #endregion
 
         #region Properties

--- a/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
@@ -124,16 +124,17 @@ namespace Blazorise.DataGrid
             return FormatDisplayValue( GetValue( item ) );
         }
 
-        public bool CellValuesAreEditable()
-        {
-            return Editable &&
-                ( ( CellsEditableOnNewCommand && ParentDataGrid?.EditState == DataGridEditState.New )
-                || ( CellsEditableOnEditCommand && ParentDataGrid?.EditState == DataGridEditState.Edit ) );
-        }
-
         #endregion
 
         #region Properties
+
+        /// <summary>
+        /// Returns true if the cell value is editable.
+        /// </summary>
+        public bool CellValueIsEditable
+            => Editable &&
+            ( ( CellsEditableOnNewCommand && ParentDataGrid?.EditState == DataGridEditState.New )
+            || ( CellsEditableOnEditCommand && ParentDataGrid?.EditState == DataGridEditState.Edit ) );
 
         /// <summary>
         /// Gets or sets the current sort direction.

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor
@@ -28,7 +28,7 @@
                         @if ( column.ColumnType == DataGridColumnType.Command )
                             continue;
 
-                        @if ( column.CellValuesAreEditable() )
+                        @if ( column.CellValueIsEditable )
                         {
                             <Field ColumnSize="@column.PopupFieldColumnSize" Padding="Blazorise.Padding.Is2.OnX.Is2.OnY">
                                 <Field>

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridModal.razor
@@ -28,7 +28,7 @@
                         @if ( column.ColumnType == DataGridColumnType.Command )
                             continue;
 
-                        @if ( column.Editable )
+                        @if ( column.CellValuesAreEditable() )
                         {
                             <Field ColumnSize="@column.PopupFieldColumnSize" Padding="Blazorise.Padding.Is2.OnX.Is2.OnY">
                                 <Field>

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor
@@ -16,7 +16,7 @@
                     @if ( column.ColumnType == DataGridColumnType.Command )
                         continue;
 
-                    @if ( CellAreEditable( column ) )
+                    @if ( column.CellValuesAreEditable() )
                     {
                         <Column ColumnSize="ColumnSize.IsHalf.OnDesktop" Padding="Blazorise.Padding.Is2.OnX.Is2.OnY">
                             <Field>
@@ -85,7 +85,7 @@ else if ( EditMode == DataGridEditMode.Inline )
             else if ( column.Displayable )
             {
                 <TableRowCell width="@column.Width">
-                    @if ( ParentDataGrid?.Editable == true && CellAreEditable( column ) )
+                    @if ( ParentDataGrid?.Editable == true && column.CellValuesAreEditable() )
                     {
                         <_DataGridCell TItem="TItem" Column="@column" Item="@Item" CellEditContext="@CellValues[column.ElementId]" ShowValidationFeedback="@( ParentDataGrid?.ShowValidationFeedback ?? false )" />
                     }

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor
@@ -16,7 +16,7 @@
                     @if ( column.ColumnType == DataGridColumnType.Command )
                         continue;
 
-                    @if ( column.CellValuesAreEditable() )
+                    @if ( column.CellValueIsEditable )
                     {
                         <Column ColumnSize="ColumnSize.IsHalf.OnDesktop" Padding="Blazorise.Padding.Is2.OnX.Is2.OnY">
                             <Field>
@@ -85,7 +85,7 @@ else if ( EditMode == DataGridEditMode.Inline )
             else if ( column.Displayable )
             {
                 <TableRowCell width="@column.Width">
-                    @if ( ParentDataGrid?.Editable == true && column.CellValuesAreEditable() )
+                    @if ( ParentDataGrid?.Editable == true && column.CellValueIsEditable )
                     {
                         <_DataGridCell TItem="TItem" Column="@column" Item="@Item" CellEditContext="@CellValues[column.ElementId]" ShowValidationFeedback="@( ParentDataGrid?.ShowValidationFeedback ?? false )" />
                     }

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridRowEdit.razor.cs
@@ -22,13 +22,6 @@ namespace Blazorise.DataGrid
 
         #region Methods
 
-        protected bool CellAreEditable( DataGridColumn<TItem> column )
-        {
-            return column.Editable &&
-                ( ( column.CellsEditableOnNewCommand && ParentDataGrid?.EditState == DataGridEditState.New )
-                || ( column.CellsEditableOnEditCommand && ParentDataGrid?.EditState == DataGridEditState.Edit ) );
-        }
-
         protected void ValidationsStatusChanged( ValidationsStatusChangedEventArgs args )
         {
             isInvalid = args.Status == ValidationStatus.Error;


### PR DESCRIPTION
- fix #1362, #1568 
- Renamed CellAreEditable and moved the method into column.
- Used this method also at DataGridModal to get the same behavior for popup.
