### PR TITLE
Better background color for tooltip opacity

### DIFF
--- a/Source/Blazorise/Styles/_variables.scss
+++ b/Source/Blazorise/Styles/_variables.scss
@@ -17,7 +17,7 @@ $tooltip-arrow-size: 6px !default;
 $tooltip-background-color-r: var(--b-tooltip-background-color-r, 128) !default;
 $tooltip-background-color-g: var(--b-tooltip-background-color-g, 128) !default;
 $tooltip-background-color-b: var(--b-tooltip-background-color-b, 128) !default;
-$tooltip-background-opacity: 0.9 !default;
+$tooltip-background-opacity: var(--b-tooltip-background-opacity, 0.9) !default;
 $tooltip-color: var(--b-tooltip-color, #ffffff) !default;
 $tooltip-font-family: $font-family-base !default;
 $tooltip-font-size: var(--b-tooltip-font-size, $font-size-sm) !default;

--- a/Source/Blazorise/Styles/tooltip.scss
+++ b/Source/Blazorise/Styles/tooltip.scss
@@ -7,7 +7,7 @@
         content: "";
         border-style: solid;
         border-width: $tooltip-arrow-size;
-        border-color: #{"rgba("}$tooltip-background-color-r, $tooltip-background-color-g, $tooltip-background-color-b, $tooltip-background-opacity#{")"} transparent transparent transparent;
+        border-color: #{"RGBA("}$tooltip-background-color-r, $tooltip-background-color-g, $tooltip-background-color-b, $tooltip-background-opacity#{")"} transparent transparent transparent;
         margin-bottom: $tooltip-arrow-size * -1 + 1;
     }
 
@@ -16,7 +16,7 @@
 
 @mixin tooltip-box {
     &::before {
-        background: #{"rgba("}#{$tooltip-background-color-r}, #{$tooltip-background-color-g}, #{$tooltip-background-color-b}, #{$tooltip-background-opacity}#{")"};
+        background: #{"RGBA("}$tooltip-background-color-r, $tooltip-background-color-g, $tooltip-background-color-b, $tooltip-background-opacity#{")"};
         border-radius: $tooltip-radius;
         content: attr(data-tooltip);
         padding: $tooltip-padding;
@@ -88,19 +88,19 @@
             &.b-tooltip-#{$name} {
                 &.b-tooltip-bottom {
                     &::after {
-                        border-color: transparent transparent rgba($color, $tooltip-background-opacity) transparent;
+                        border-color: transparent transparent RGBA($color, $tooltip-background-opacity) transparent;
                     }
                 }
 
                 &.b-tooltip-left {
                     &::after {
-                        border-color: transparent transparent transparent rgba($color, $tooltip-background-opacity);
+                        border-color: transparent transparent transparent RGBA($color, $tooltip-background-opacity);
                     }
                 }
 
                 &.b-tooltip-right {
                     &::after {
-                        border-color: transparent rgba($color, $tooltip-background-opacity) transparent transparent;
+                        border-color: transparent RGBA($color, $tooltip-background-opacity) transparent transparent;
                     }
                 }
 
@@ -108,12 +108,12 @@
                 &:not(.b-tooltip-left),
                 &:not(.b-tooltip-right) {
                     &::after {
-                        border-color: rgba($color, $tooltip-background-opacity) transparent transparent transparent;
+                        border-color: RGBA($color, $tooltip-background-opacity) transparent transparent transparent;
                     }
                 }
 
                 &:before {
-                    background-color: rgba($color, $tooltip-background-opacity);
+                    background-color: RGBA($color, $tooltip-background-opacity);
                     color: $color-invert;
                 }
             }

--- a/Source/Blazorise/Themes/Models/ThemeTooltipOptions.cs
+++ b/Source/Blazorise/Themes/Models/ThemeTooltipOptions.cs
@@ -5,9 +5,10 @@ namespace Blazorise
 {
     public class ThemeTooltipOptions : BasicOptions
     {
-        public string BackgroundColor { get; set; } = "#808080";
-
-        public float? BackgroundOpacity { get; set; } = 90f;
+        /// <summary>
+        /// Tooltip background color. Can contain alpha value in 8-hex formated color.
+        /// </summary>
+        public string BackgroundColor { get; set; } = "#808080e6";
 
         public string Color { get; set; } = "#ffffff";
 

--- a/Source/Blazorise/Themes/ThemeGenerator.cs
+++ b/Source/Blazorise/Themes/ThemeGenerator.cs
@@ -339,11 +339,7 @@ namespace Blazorise
                 variables[ThemeVariables.TooltipBackgroundColorR] = backgroundColor.R.ToString( CultureInfo.InvariantCulture );
                 variables[ThemeVariables.TooltipBackgroundColorG] = backgroundColor.G.ToString( CultureInfo.InvariantCulture );
                 variables[ThemeVariables.TooltipBackgroundColorB] = backgroundColor.B.ToString( CultureInfo.InvariantCulture );
-            }
-
-            if ( tooltipOptions?.BackgroundOpacity != null )
-            {
-                variables[ThemeVariables.TooltipBackgroundOpacity] = tooltipOptions.BackgroundOpacity.Value.ToString( CultureInfo.InvariantCulture );
+                variables[ThemeVariables.TooltipBackgroundOpacity] = ( backgroundColor.A / 255f ).ToString( "n2", CultureInfo.InvariantCulture );
             }
 
             if ( tooltipOptions?.Color != null )

--- a/Source/Blazorise/wwwroot/blazorise.css
+++ b/Source/Blazorise/wwwroot/blazorise.css
@@ -86,7 +86,7 @@
         content: "";
         border-style: solid;
         border-width: 6px;
-        border-color: rgba(var(--b-tooltip-background-color-r, 128), var(--b-tooltip-background-color-g, 128), var(--b-tooltip-background-color-b, 128), 0.9) transparent transparent transparent;
+        border-color: RGBA(var(--b-tooltip-background-color-r, 128), var(--b-tooltip-background-color-g, 128), var(--b-tooltip-background-color-b, 128), var(--b-tooltip-background-opacity, 0.9)) transparent transparent transparent;
         margin-bottom: -5px; }
     [data-tooltip]:not(.is-loading)::after, [data-tooltip]:not(.is-disabled)::after, [data-tooltip]:not([disabled])::after {
         top: 0;
@@ -97,9 +97,9 @@
         margin-right: auto;
         margin-bottom: auto;
         margin-left: -5px;
-        border-color: rgba(var(--b-tooltip-background-color-r, 128), var(--b-tooltip-background-color-g, 128), var(--b-tooltip-background-color-b, 128), 0.9) transparent transparent transparent; }
+        border-color: rgba(var(--b-tooltip-background-color-r, 128), var(--b-tooltip-background-color-g, 128), var(--b-tooltip-background-color-b, 128), var(--b-tooltip-background-opacity, 0.9)) transparent transparent transparent; }
     [data-tooltip]:not(.is-loading)::before, [data-tooltip]:not(.is-disabled)::before, [data-tooltip]:not([disabled])::before {
-        background: rgba(var(--b-tooltip-background-color-r, 128), var(--b-tooltip-background-color-g, 128), var(--b-tooltip-background-color-b, 128), 0.9);
+        background: RGBA(var(--b-tooltip-background-color-r, 128), var(--b-tooltip-background-color-g, 128), var(--b-tooltip-background-color-b, 128), var(--b-tooltip-background-opacity, 0.9));
         border-radius: var(--b-tooltip-border-radius, 4px);
         content: attr(data-tooltip);
         padding: var(--b-tooltip-padding, 0.5rem 1rem);
@@ -123,7 +123,7 @@
         margin-right: auto;
         margin-bottom: -5px;
         margin-left: -5px;
-        border-color: transparent transparent rgba(var(--b-tooltip-background-color-r, 128), var(--b-tooltip-background-color-g, 128), var(--b-tooltip-background-color-b, 128), 0.9) transparent; }
+        border-color: transparent transparent rgba(var(--b-tooltip-background-color-r, 128), var(--b-tooltip-background-color-g, 128), var(--b-tooltip-background-color-b, 128), var(--b-tooltip-background-opacity, 0.9)) transparent; }
     [data-tooltip]:not(.is-loading).b-tooltip-bottom::before, [data-tooltip]:not(.is-disabled).b-tooltip-bottom::before, [data-tooltip]:not([disabled]).b-tooltip-bottom::before {
         top: auto;
         right: auto;
@@ -141,7 +141,7 @@
         margin-right: auto;
         margin-bottom: -6px;
         margin-left: -11px;
-        border-color: transparent transparent transparent rgba(var(--b-tooltip-background-color-r, 128), var(--b-tooltip-background-color-g, 128), var(--b-tooltip-background-color-b, 128), 0.9); }
+        border-color: transparent transparent transparent rgba(var(--b-tooltip-background-color-r, 128), var(--b-tooltip-background-color-g, 128), var(--b-tooltip-background-color-b, 128), var(--b-tooltip-background-opacity, 0.9)); }
     [data-tooltip]:not(.is-loading).b-tooltip-left::before, [data-tooltip]:not(.is-disabled).b-tooltip-left::before, [data-tooltip]:not([disabled]).b-tooltip-left::before {
         top: auto;
         right: auto;
@@ -157,7 +157,7 @@
         margin-right: -11px;
         margin-bottom: -6px;
         margin-left: auto;
-        border-color: transparent rgba(var(--b-tooltip-background-color-r, 128), var(--b-tooltip-background-color-g, 128), var(--b-tooltip-background-color-b, 128), 0.9) transparent transparent; }
+        border-color: transparent rgba(var(--b-tooltip-background-color-r, 128), var(--b-tooltip-background-color-g, 128), var(--b-tooltip-background-color-b, 128), var(--b-tooltip-background-opacity, 0.9)) transparent transparent; }
     [data-tooltip]:not(.is-loading).b-tooltip-right::before, [data-tooltip]:not(.is-disabled).b-tooltip-right::before, [data-tooltip]:not([disabled]).b-tooltip-right::before {
         top: auto;
         right: -11px;
@@ -173,15 +173,15 @@
         white-space: normal;
         word-break: keep-all; }
     [data-tooltip]:not(.is-loading).b-tooltip-primary.b-tooltip-bottom::after, [data-tooltip]:not(.is-disabled).b-tooltip-primary.b-tooltip-bottom::after, [data-tooltip]:not([disabled]).b-tooltip-primary.b-tooltip-bottom::after {
-        border-color: transparent transparent rgba(142, 51, 41, 0.9) transparent; }
+        border-color: transparent transparent RGBA(#8e3329, var(--b-tooltip-background-opacity, 0.9)) transparent; }
     [data-tooltip]:not(.is-loading).b-tooltip-primary.b-tooltip-left::after, [data-tooltip]:not(.is-disabled).b-tooltip-primary.b-tooltip-left::after, [data-tooltip]:not([disabled]).b-tooltip-primary.b-tooltip-left::after {
-        border-color: transparent transparent transparent rgba(142, 51, 41, 0.9); }
+        border-color: transparent transparent transparent RGBA(#8e3329, var(--b-tooltip-background-opacity, 0.9)); }
     [data-tooltip]:not(.is-loading).b-tooltip-primary.b-tooltip-right::after, [data-tooltip]:not(.is-disabled).b-tooltip-primary.b-tooltip-right::after, [data-tooltip]:not([disabled]).b-tooltip-primary.b-tooltip-right::after {
-        border-color: transparent rgba(142, 51, 41, 0.9) transparent transparent; }
+        border-color: transparent RGBA(#8e3329, var(--b-tooltip-background-opacity, 0.9)) transparent transparent; }
     [data-tooltip]:not(.is-loading).b-tooltip-primary:not(.b-tooltip-bottom)::after, [data-tooltip]:not(.is-loading).b-tooltip-primary:not(.b-tooltip-left)::after, [data-tooltip]:not(.is-loading).b-tooltip-primary:not(.b-tooltip-right)::after, [data-tooltip]:not(.is-disabled).b-tooltip-primary:not(.b-tooltip-bottom)::after, [data-tooltip]:not(.is-disabled).b-tooltip-primary:not(.b-tooltip-left)::after, [data-tooltip]:not(.is-disabled).b-tooltip-primary:not(.b-tooltip-right)::after, [data-tooltip]:not([disabled]).b-tooltip-primary:not(.b-tooltip-bottom)::after, [data-tooltip]:not([disabled]).b-tooltip-primary:not(.b-tooltip-left)::after, [data-tooltip]:not([disabled]).b-tooltip-primary:not(.b-tooltip-right)::after {
-        border-color: rgba(142, 51, 41, 0.9) transparent transparent transparent; }
+        border-color: RGBA(#8e3329, var(--b-tooltip-background-opacity, 0.9)) transparent transparent transparent; }
     [data-tooltip]:not(.is-loading).b-tooltip-primary:before, [data-tooltip]:not(.is-disabled).b-tooltip-primary:before, [data-tooltip]:not([disabled]).b-tooltip-primary:before {
-        background-color: rgba(142, 51, 41, 0.9);
+        background-color: RGBA(#8e3329, var(--b-tooltip-background-opacity, 0.9));
         color: #8e3329; }
     [data-tooltip]:not(.is-loading):focus::before, [data-tooltip]:not(.is-loading):focus::after, [data-tooltip]:not(.is-loading):hover::before, [data-tooltip]:not(.is-loading):hover::after, [data-tooltip]:not(.is-loading).b-tooltip-active::before, [data-tooltip]:not(.is-loading).b-tooltip-active::after, [data-tooltip]:not(.is-disabled):focus::before, [data-tooltip]:not(.is-disabled):focus::after, [data-tooltip]:not(.is-disabled):hover::before, [data-tooltip]:not(.is-disabled):hover::after, [data-tooltip]:not(.is-disabled).b-tooltip-active::before, [data-tooltip]:not(.is-disabled).b-tooltip-active::after, [data-tooltip]:not([disabled]):focus::before, [data-tooltip]:not([disabled]):focus::after, [data-tooltip]:not([disabled]):hover::before, [data-tooltip]:not([disabled]):hover::after, [data-tooltip]:not([disabled]).b-tooltip-active::before, [data-tooltip]:not([disabled]).b-tooltip-active::after {
         opacity: 1;


### PR DESCRIPTION
resolve #1172 Tooltip transparency not working

**Done:**

- Removed `BackgroundOpacity` from theme options
- Alpha value is now set through BackgroundColor