### PR TITLE
DataGrid: fix double ReadData

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -108,39 +108,7 @@ namespace Blazorise.DataGrid
             newItemCreator = new Lazy<Func<TItem>>( () => FunctionCompiler.CreateNewItem<TItem>() );
 
             paginationTemplates = new PaginationTemplates<TItem>();
-            paginationContext = new PaginationContext<TItem>( this );
-
-            paginationContext.SubscribeOnPageSizeChanged( pageSize =>
-            {
-                InvokeAsync( () => PageSizeChanged.InvokeAsync( pageSize ) );
-
-                // When using manual mode, a user is in control when StateHasChanged will be called
-                // so we just need to call HandleReadData.
-                if ( ManualReadMode )
-                {
-                    InvokeAsync( HandleReadData );
-                }
-                else
-                {
-                    InvokeAsync( StateHasChanged );
-                }
-            } );
-
-            paginationContext.SubscribeOnPageChanged( currentPage =>
-            {
-                InvokeAsync( () => PageChanged.InvokeAsync( new DataGridPageChangedEventArgs( currentPage, PageSize ) ) );
-
-                // When using manual mode, a user is in control when StateHasChanged will be called
-                // so we just need to call HandleReadData.
-                if ( ManualReadMode )
-                {
-                    InvokeAsync( HandleReadData );
-                }
-                else
-                {
-                    InvokeAsync( StateHasChanged );
-                }
-            } );
+            paginationContext = new PaginationContext<TItem>( this );            
         }
 
         #endregion
@@ -182,6 +150,38 @@ namespace Blazorise.DataGrid
         {
             if ( firstRender )
             {
+                paginationContext.SubscribeOnPageSizeChanged( pageSize =>
+                {
+                    InvokeAsync( () => PageSizeChanged.InvokeAsync( pageSize ) );
+
+                    // When using manual mode, a user is in control when StateHasChanged will be called
+                    // so we just need to call HandleReadData.
+                    if ( ManualReadMode )
+                    {
+                        InvokeAsync( HandleReadData );
+                    }
+                    else
+                    {
+                        InvokeAsync( StateHasChanged );
+                    }
+                } );
+
+                paginationContext.SubscribeOnPageChanged( currentPage =>
+                {
+                    InvokeAsync( () => PageChanged.InvokeAsync( new DataGridPageChangedEventArgs( currentPage, PageSize ) ) );
+
+                    // When using manual mode, a user is in control when StateHasChanged will be called
+                    // so we just need to call HandleReadData.
+                    if ( ManualReadMode )
+                    {
+                        InvokeAsync( HandleReadData );
+                    }
+                    else
+                    {
+                        InvokeAsync( StateHasChanged );
+                    }
+                } );
+
                 if ( ManualReadMode )
                     return HandleReadData();
 

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -108,7 +108,7 @@ namespace Blazorise.DataGrid
             newItemCreator = new Lazy<Func<TItem>>( () => FunctionCompiler.CreateNewItem<TItem>() );
 
             paginationTemplates = new PaginationTemplates<TItem>();
-            paginationContext = new PaginationContext<TItem>( this );            
+            paginationContext = new PaginationContext<TItem>( this );
         }
 
         #endregion


### PR DESCRIPTION
Moved paginationContext's events subscription from constructor into OnAfterRender to prevent them beeing triggered by the first SetParameters.

fix #1609