### PR TITLE
Add OpenReadStream for IFileEntry and FileEdit

### DIFF
--- a/Source/Blazorise/Blazorise.csproj
+++ b/Source/Blazorise/Blazorise.csproj
@@ -16,4 +16,8 @@
     <None Include="..\..\NuGet\Blazorise.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.IO.Pipelines" Version="5.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/Source/Blazorise/Blazorise.csproj
+++ b/Source/Blazorise/Blazorise.csproj
@@ -16,8 +16,4 @@
     <None Include="..\..\NuGet\Blazorise.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.IO.Pipelines" Version="5.0.0" />
-  </ItemGroup>
-
 </Project>

--- a/Source/Blazorise/FileEdit.razor.cs
+++ b/Source/Blazorise/FileEdit.razor.cs
@@ -194,6 +194,11 @@ namespace Blazorise
                 .WriteToStreamAsync( stream, CancellationToken.None );
         }
 
+        public Stream OpenReadStream( FileEntry fileEntry, CancellationToken cancellationToken )
+        {
+            return new RemoteFileEntryStream( JSRunner, ElementRef, fileEntry, this, MaxMessageSize, SegmentFetchTimeout, cancellationToken  );
+        }
+
         /// <summary>
         /// Manaully resets the input file value.
         /// </summary>
@@ -246,6 +251,11 @@ namespace Blazorise
         /// Gets or sets the max message size when uploading the file.
         /// </summary>
         [Parameter] public int MaxMessageSize { get; set; } = 20 * 1024;
+
+        /// <summary>
+        /// Gets or sets the Segment Fetch Timeout when uploading the file.
+        /// </summary>
+        [Parameter] public TimeSpan SegmentFetchTimeout { get; set; } = TimeSpan.FromMinutes( 1 );
 
         /// <summary>
         /// Occurs every time the selected file(s) has changed.

--- a/Source/Blazorise/FileEntry.cs
+++ b/Source/Blazorise/FileEntry.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 #endregion
 
@@ -20,6 +21,16 @@ namespace Blazorise
         public async Task WriteToStreamAsync( Stream stream )
         {
             await Owner.WriteToStreamAsync( this, stream );
+        }
+
+        public Stream OpenReadStream( long maxAllowedSize = 512000, CancellationToken cancellationToken = default )
+        {
+            if ( Size > maxAllowedSize )
+            {
+                throw new IOException( $"Supplied file with size {Size} bytes exceeds the maximum of {maxAllowedSize} bytes." );
+            }
+
+            return Owner.OpenReadStream( this, cancellationToken );
         }
 
         #endregion

--- a/Source/Blazorise/IFileEntry.cs
+++ b/Source/Blazorise/IFileEntry.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 #endregion
 
@@ -39,5 +40,27 @@ namespace Blazorise
         /// <param name="stream">Stream to which the upload process if writing.</param>
         /// <returns></returns>
         Task WriteToStreamAsync( Stream stream );
+
+        /// <summary>Opens the stream for reading the uploaded file.</summary>
+        /// <param name="maxAllowedSize">
+        /// The maximum number of bytes that can be supplied by the Stream. Defaults to 500 KB.
+        /// <para>
+        /// Calling <see cref="M:Blazorise.IFileEntry.OpenReadStream(System.Int64,System.Threading.CancellationToken)" />
+        /// will throw if the file's size, as specified by <see cref="P:Blazorize.IFileEntry.Size" /> is larger than
+        /// <paramref name="maxAllowedSize" />. By default, if the user supplies a file larger than 500 KB, this method will throw an exception.
+        /// </para>
+        /// <para>
+        /// It is valuable to choose a size limit that corresponds to your use case. If you allow excessively large files, this
+        /// may result in excessive consumption of memory or disk/database space, depending on what your code does
+        /// with the supplied <see cref="T:System.IO.Stream" />.
+        /// </para>
+        /// <para>
+        /// For Blazor Server in particular, beware of reading the entire stream into a memory buffer unless you have
+        /// passed a suitably low size limit, since you will be consuming that memory on the server.
+        /// </para>
+        /// </param>
+        /// <param name="cancellationToken">A cancellation token to signal the cancellation of streaming file data.</param>
+        /// <exception cref="T:System.IO.IOException">Thrown if the file's length exceeds the <paramref name="maxAllowedSize" /> value.</exception>
+        Stream OpenReadStream( long maxAllowedSize = 512000, CancellationToken cancellationToken = default );
     }
 }

--- a/Source/Blazorise/RemoteFileEntryStream.cs
+++ b/Source/Blazorise/RemoteFileEntryStream.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Buffers;
+using System.IO;
+using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+
+namespace Blazorise
+{
+    internal class RemoteFileEntryStream : Stream
+    {
+        private readonly IJSRunner _jsRunner;
+        private readonly ElementReference _elementRef;
+        private readonly FileEntry _fileEntry;
+        private readonly FileEdit _fileEdit;
+        private readonly int _maxMessageSize;
+        private readonly TimeSpan _segmentFetchTimeout;
+        private readonly PipeReader _pipeReader;
+        private readonly CancellationTokenSource _fillBufferCts;
+        private bool _isReadingCompleted;
+        private bool _isDisposed;
+        private long _position;
+
+        public RemoteFileEntryStream( IJSRunner jsRunner, ElementReference elementRef, FileEntry fileEntry, FileEdit fileEdit, int maxMessageSize, TimeSpan segmentFetchTimeout, CancellationToken cancellationToken )
+        {
+            _jsRunner = jsRunner;
+            _elementRef = elementRef;
+            _fileEntry = fileEntry;
+            _fileEdit = fileEdit;
+            _maxMessageSize = maxMessageSize;
+            _segmentFetchTimeout = segmentFetchTimeout;
+
+            var pipe = new Pipe( new PipeOptions( pauseWriterThreshold: _maxMessageSize, resumeWriterThreshold: _maxMessageSize ) );
+            _pipeReader = pipe.Reader;
+            _fillBufferCts = CancellationTokenSource.CreateLinkedTokenSource( cancellationToken );
+
+            _ = FillBuffer( pipe.Writer, _fillBufferCts.Token );
+        }
+
+        private async Task FillBuffer( PipeWriter writer, CancellationToken cancellationToken )
+        {
+            long offset = 0;
+
+            try
+            {
+                while ( offset < _fileEntry.Size )
+                {
+                    var pipeBuffer = writer.GetMemory( _maxMessageSize );
+
+                    try
+                    {
+                        using var readSegmentCts = CancellationTokenSource.CreateLinkedTokenSource( cancellationToken );
+                        readSegmentCts.CancelAfter( _segmentFetchTimeout );
+
+                        var length = (int)Math.Min( _maxMessageSize, _fileEntry.Size - offset );
+                        var base64 = await _jsRunner.ReadDataAsync( cancellationToken, _elementRef, _fileEntry.Id, offset, length );
+                        var bytes = Convert.FromBase64String( base64 );
+
+                        if ( bytes is null || bytes.Length != length )
+                        {
+                            throw new InvalidOperationException(
+                                $"A segment with size {bytes?.Length ?? 0} bytes was received, but {length} bytes were expected." );
+                        }
+
+                        bytes.CopyTo( pipeBuffer );
+                        writer.Advance( length );
+                        offset += length;
+
+                        var result = await writer.FlushAsync( cancellationToken );
+
+                        await Task.WhenAll(
+                            _fileEdit.UpdateFileWrittenAsync( _fileEntry, offset, bytes ),
+                            _fileEdit.UpdateFileProgressAsync( _fileEntry, bytes.Length ) );
+
+                        if ( result.IsCompleted )
+                        {
+                            break;
+                        }
+                    }
+                    catch ( Exception e )
+                    {
+                        await writer.CompleteAsync( e );
+                        return;
+                    }
+                }
+            }
+            finally
+            {
+                await _fileEdit.UpdateFileEndedAsync( _fileEntry, offset == _fileEntry.Size );
+            }
+
+            await writer.CompleteAsync();
+        }
+
+        protected async ValueTask<int> CopyFileDataIntoBuffer( long sourceOffset, Memory<byte> destination, CancellationToken cancellationToken )
+        {
+            if ( _isReadingCompleted )
+            {
+                return 0;
+            }
+
+            int totalBytesCopied = 0;
+
+            while ( destination.Length > 0 )
+            {
+                var result = await _pipeReader.ReadAsync( cancellationToken );
+                var bytesToCopy = (int)Math.Min( result.Buffer.Length, destination.Length );
+
+                if ( bytesToCopy == 0 )
+                {
+                    if ( result.IsCompleted )
+                    {
+                        _isReadingCompleted = true;
+                        await _pipeReader.CompleteAsync();
+                    }
+
+                    break;
+                }
+
+                var slice = result.Buffer.Slice( 0, bytesToCopy );
+                slice.CopyTo( destination.Span );
+
+                _pipeReader.AdvanceTo( slice.End );
+
+                totalBytesCopied += bytesToCopy;
+                destination = destination.Slice( bytesToCopy );
+            }
+
+            return totalBytesCopied;
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => _fileEntry.Size;
+
+        public override long Position
+        {
+            get => _position;
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+            => throw new NotSupportedException();
+
+        public override int Read( byte[] buffer, int offset, int count )
+            => throw new NotSupportedException( "Synchronous reads are not supported." );
+
+        public override long Seek( long offset, SeekOrigin origin )
+            => throw new NotSupportedException();
+
+        public override void SetLength( long value )
+            => throw new NotSupportedException();
+
+        public override void Write( byte[] buffer, int offset, int count )
+            => throw new NotSupportedException();
+
+        public override Task<int> ReadAsync( byte[] buffer, int offset, int count, CancellationToken cancellationToken )
+            => ReadAsync( new Memory<byte>( buffer, offset, count ), cancellationToken ).AsTask();
+
+        public override async ValueTask<int> ReadAsync( Memory<byte> buffer, CancellationToken cancellationToken = default )
+        {
+            int maxBytesToRead = (int)( Length - Position );
+
+            if ( maxBytesToRead > buffer.Length )
+            {
+                maxBytesToRead = buffer.Length;
+            }
+
+            if ( maxBytesToRead <= 0 )
+            {
+                return 0;
+            }
+
+            var bytesRead = await CopyFileDataIntoBuffer( _position, buffer.Slice( 0, maxBytesToRead ), cancellationToken );
+
+            _position += bytesRead;
+
+            return bytesRead;
+        }
+
+        protected override void Dispose( bool disposing )
+        {
+            if ( _isDisposed )
+            {
+                return;
+            }
+
+            _fillBufferCts.Cancel();
+
+            _isDisposed = true;
+
+            base.Dispose( disposing );
+        }
+    }
+}

--- a/Source/Blazorise/RemoteFileEntryStream.cs
+++ b/Source/Blazorise/RemoteFileEntryStream.cs
@@ -1,7 +1,11 @@
 ﻿using System;
 using System.Buffers;
+using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
+#if NET5_0
 using System.IO.Pipelines;
+#endif
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
@@ -16,9 +20,12 @@ namespace Blazorise
         private readonly FileEdit _fileEdit;
         private readonly int _maxMessageSize;
         private readonly TimeSpan _segmentFetchTimeout;
+#if NET5_0
         private readonly PipeReader _pipeReader;
+#elif NETSTANDARD2_1
+        private readonly IAsyncEnumerator<byte[]> _pipe;
+#endif
         private readonly CancellationTokenSource _fillBufferCts;
-        private bool _isReadingCompleted;
         private bool _isDisposed;
         private long _position;
 
@@ -30,14 +37,18 @@ namespace Blazorise
             _fileEdit = fileEdit;
             _maxMessageSize = maxMessageSize;
             _segmentFetchTimeout = segmentFetchTimeout;
-
+            _fillBufferCts = CancellationTokenSource.CreateLinkedTokenSource( cancellationToken );
+#if NET5_0
             var pipe = new Pipe( new PipeOptions( pauseWriterThreshold: _maxMessageSize, resumeWriterThreshold: _maxMessageSize ) );
             _pipeReader = pipe.Reader;
-            _fillBufferCts = CancellationTokenSource.CreateLinkedTokenSource( cancellationToken );
 
             _ = FillBuffer( pipe.Writer, _fillBufferCts.Token );
+#elif NETSTANDARD2_1
+            _pipe = CreatePipe( _fillBufferCts.Token ).GetAsyncEnumerator(  );
+#endif
         }
 
+#if NET5_0
         private async Task FillBuffer( PipeWriter writer, CancellationToken cancellationToken )
         {
             long offset = 0;
@@ -129,6 +140,44 @@ namespace Blazorise
 
             return totalBytesCopied;
         }
+#elif NETSTANDARD2_1
+        private async IAsyncEnumerable<byte[]> CreatePipe( [EnumeratorCancellation] CancellationToken cancellationToken )
+        {
+            long offset = 0;
+
+            try
+            {
+                while ( offset < _fileEntry.Size )
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    using var readSegmentCts = CancellationTokenSource.CreateLinkedTokenSource( cancellationToken );
+                    readSegmentCts.CancelAfter( _segmentFetchTimeout );
+
+                    var length = (int)Math.Min( _maxMessageSize, _fileEntry.Size - offset );
+                    var base64 = await _jsRunner.ReadDataAsync( cancellationToken, _elementRef, _fileEntry.Id, offset, length );
+                    var bytes = Convert.FromBase64String( base64 );
+
+                    if ( bytes is null || bytes.Length != length )
+                    {
+                        throw new InvalidOperationException( $"A segment with size {bytes?.Length ?? 0} bytes was received, but {length} bytes were expected." );
+                    }
+
+                    offset += length;
+
+                    yield return bytes;
+
+                    await Task.WhenAll(
+                        _fileEdit.UpdateFileWrittenAsync( _fileEntry, offset, bytes ),
+                        _fileEdit.UpdateFileProgressAsync( _fileEntry, offset ) );
+                }
+            }
+            finally
+            {
+                await _fileEdit.UpdateFileEndedAsync( _fileEntry, offset == _fileEntry.Size );
+            }
+        }
+#endif
 
         public override bool CanRead => true;
 
@@ -175,9 +224,13 @@ namespace Blazorise
             {
                 return 0;
             }
-
+#if NET5_0
             var bytesRead = await CopyFileDataIntoBuffer( _position, buffer.Slice( 0, maxBytesToRead ), cancellationToken );
-
+#elif NETSTANDARD2_1
+            await _pipe.MoveNextAsync();
+            _pipe.Current.CopyTo( buffer );
+            var bytesRead = _pipe.Current.Length;
+#endif
             _position += bytesRead;
 
             return bytesRead;
@@ -196,5 +249,14 @@ namespace Blazorise
 
             base.Dispose( disposing );
         }
+
+
+#if NETSTANDARD2_1
+        public async override ValueTask DisposeAsync()
+        {
+            await _pipe.DisposeAsync();
+            await base.DisposeAsync();
+        }
+#endif
     }
 }


### PR DESCRIPTION
Based largely on the implementation from AspNet with some small tweaks for Blazorise. 

It does require the `System.IO.Pipelines` package which might be unwarranted at this point.

Closes #1681 