### PR TITLE
Clear Filter Bug Fix: Filter Template usage

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
@@ -176,7 +176,7 @@
                         <DataGridColumn TextAlignment="TextAlignment.Center" TItem="Employee" Field="@nameof( Employee.Id )" Caption="#" Sortable="false" Width="60px" />
                         <DataGridColumn TItem="Employee" Field="@nameof( Employee.FirstName )" Caption="First Name" Validator="@CheckFirstName" Editable="true">
                             <FilterTemplate>
-                                <TextEdit Placeholder="Search name" TextChanged="@(v=>context.TriggerFilterChange(v))" />
+                                <TextEdit Placeholder="Search name" Text="@context.SearchValue"  TextChanged="@(v=> context.TriggerFilterChange(v))" />
                             </FilterTemplate>
                         </DataGridColumn>
                         <DataGridColumn TItem="Employee" Field="@nameof( Employee.LastName )" Caption="Last Name" Editable="true" ValidationPattern="[A-Za-z]{3}" />
@@ -186,13 +186,16 @@
                                 <Icon Name="IconName.City" /> @context.Caption
                             </CaptionTemplate>
                             <FilterTemplate>
-                                <Select TValue="string" SelectedValueChanged="@(e => context.TriggerFilterChange(e == "*" ? "" : e.ToString()))">
+                                @{ 
+                                    var selectedValue = @context.SearchValue ?? "*";
+                                <Select TValue="string" SelectedValue="@selectedValue" SelectedValueChanged="@(e => context.TriggerFilterChange(e == "*" ? "" : e.ToString()))">
                                     <SelectItem Value="@("*")">All</SelectItem>
                                     @foreach ( var item in dataModels )
                                     {
                                         <SelectItem Value="@item.City">@item.City</SelectItem>
                                     }
                                 </Select>
+                                }
                             </FilterTemplate>
                         </DataGridColumn>
                         <DataGridColumn TItem="Employee" Field="@nameof( Employee.Zip )" Caption="Zip" Editable="true" />

--- a/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
@@ -176,7 +176,7 @@
                         <DataGridColumn TextAlignment="TextAlignment.Center" TItem="Employee" Field="@nameof( Employee.Id )" Caption="#" Sortable="false" Width="60px" />
                         <DataGridColumn TItem="Employee" Field="@nameof( Employee.FirstName )" Caption="First Name" Validator="@CheckFirstName" Editable="true">
                             <FilterTemplate>
-                                <TextEdit Placeholder="Search name" Text="@context.SearchValue"  TextChanged="@(v=> context.TriggerFilterChange(v))" />
+                                <TextEdit Placeholder="Search name" Text="@context.SearchValue" TextChanged="@(v=> context.TriggerFilterChange(v))" />
                             </FilterTemplate>
                         </DataGridColumn>
                         <DataGridColumn TItem="Employee" Field="@nameof( Employee.LastName )" Caption="Last Name" Editable="true" ValidationPattern="[A-Za-z]{3}" />
@@ -186,15 +186,15 @@
                                 <Icon Name="IconName.City" /> @context.Caption
                             </CaptionTemplate>
                             <FilterTemplate>
-                                @{ 
+                                @{
                                     var selectedValue = @context.SearchValue ?? "*";
-                                <Select TValue="string" SelectedValue="@selectedValue" SelectedValueChanged="@(e => context.TriggerFilterChange(e == "*" ? "" : e.ToString()))">
-                                    <SelectItem Value="@("*")">All</SelectItem>
-                                    @foreach ( var item in dataModels )
-                                    {
-                                        <SelectItem Value="@item.City">@item.City</SelectItem>
-                                    }
-                                </Select>
+                                    <Select TValue="string" SelectedValue="@selectedValue" SelectedValueChanged="@(e => context.TriggerFilterChange(e == "*" ? "" : e.ToString()))">
+                                        <SelectItem Value="@("*")">All</SelectItem>
+                                        @foreach ( var item in dataModels )
+                                        {
+                                            <SelectItem Value="@item.City">@item.City</SelectItem>
+                                        }
+                                    </Select>
                                 }
                             </FilterTemplate>
                         </DataGridColumn>

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -92,7 +92,7 @@
                             <TableHeaderCell Class="@column.FilterCellClass" Style="@column.FilterCellStyle" width="@column.Width">
                                 @if ( column.FilterTemplate != null )
                                 {
-                                    @(column.FilterTemplate(column.Filter))
+                                    @(column.FilterTemplate( column.Filter ))
                                 }
                                 else
                                 {

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -92,7 +92,7 @@
                             <TableHeaderCell Class="@column.FilterCellClass" Style="@column.FilterCellStyle" width="@column.Width">
                                 @if ( column.FilterTemplate != null )
                                 {
-                                    @(column.FilterTemplate(column.FilterContext))
+                                    @(column.FilterTemplate(column.Filter))
                                 }
                                 else
                                 {

--- a/Source/Extensions/Blazorise.DataGrid/FilterContext.cs
+++ b/Source/Extensions/Blazorise.DataGrid/FilterContext.cs
@@ -47,12 +47,5 @@ namespace Blazorise.DataGrid
         public string SearchValue { get; set; }
 
         #endregion
-
-
-
-
-
-
-
     }
 }

--- a/Source/Extensions/Blazorise.DataGrid/FilterContext.cs
+++ b/Source/Extensions/Blazorise.DataGrid/FilterContext.cs
@@ -33,6 +33,7 @@ namespace Blazorise.DataGrid
 
         public void TriggerFilterChange( string value )
         {
+            SearchValue = value;
             FilterChanged?.Invoke( value );
         }
 


### PR DESCRIPTION
@stsrki The Clear Filter bugfix.
There's a couple of things here.
The bug only happens when using the Filter Template. I noticed the Filter Template takes in a FilterContext from a DataColumn.FilterContext property. So on the Demo both the First Name and City Column Filters have this bug.
I don't know why there exists a Filter and a FilterContext property on the DataColumn but I'm sure there's a good reason...


- The FilterContext.TriggerFilterChange wasn't modifying the filter's current SearchValue with the new Value.
- On the demo itself, both the inputs weren't correctly bound to the value.
- I made the FilterTemplate take in the Filter property instead of the FilterContext property which seems to always have the correct updated value across the code.