### PR TITLE
SnackbarStack functionality for selecting the notification life interval when calling the Push method

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Tests/ElementsPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/ElementsPage.razor
@@ -292,6 +292,32 @@
     </Column>
 </Row>
 <Row>
+    <Column>
+        <Card Margin="Margin.Is4.FromBottom">
+            <CardHeader>
+                <CardTitle>Stacked snackbars with custom intervals</CardTitle>
+            </CardHeader>
+            <CardBody>
+                <CardText>
+                    You can have a dynamicaly stacked snackbars with custom interval before close.
+                </CardText>
+            </CardBody>
+            <CardBody>
+                <Field Horizontal="true">
+                    <FieldLabel ColumnSize="ColumnSize.IsFull.OnTablet.Is2.OnDesktop">Interval</FieldLabel>
+                    <FieldBody ColumnSize="ColumnSize.IsFull.OnTablet.Is10.OnDesktop">
+                        <NumericEdit @bind-Value="this.intervalBeforeMsgClose" />
+                    </FieldBody>
+                </Field>
+                <Button Color="Color.Success" Clicked="@(()=>snackbarStack.Push("Some success message! Timeout: " + intervalBeforeMsgClose, intervalBeforeMsgClose, SnackbarColor.Success, "Ok"))">Show Success message</Button>
+                <Button Color="Color.Info" Clicked="@(()=>snackbarStack.Push("Some info message! Timeout: " + intervalBeforeMsgClose, intervalBeforeMsgClose, SnackbarColor.Info, "Ok"))">Show Info message</Button>
+                <Button Color="Color.Warning" Clicked="@(()=>snackbarStack.Push("Some warning message! Timeout: " + intervalBeforeMsgClose, intervalBeforeMsgClose, SnackbarColor.Warning, "Ok"))">Show Warning message</Button>
+                <Button Color="Color.Danger" Clicked="@(()=>snackbarStack.Push("Some danger message! Timeout: " + intervalBeforeMsgClose, intervalBeforeMsgClose, SnackbarColor.Danger, "Ok"))">Show Danger message</Button>
+            </CardBody>
+        </Card>
+    </Column>
+</Row>
+<Row>
     <Column ColumnSize="ColumnSize.Is12.OnMobile">
         <Jumbotron Background="Background.Primary" Margin="Margin.Is4.FromBottom">
             <JumbotronTitle Size="JumbotronTitleSize.Is4">Hello, world!</JumbotronTitle>
@@ -509,6 +535,8 @@
     Snackbar snackbarDark;
 
     SnackbarStack snackbarStack;
+
+    double intervalBeforeMsgClose = 2000;
 
     bool dismisableAlert1 = true;
     bool dismisableAlert2 = true;

--- a/Source/Extensions/Blazorise.Snackbar/SnackbarStack.razor
+++ b/Source/Extensions/Blazorise.Snackbar/SnackbarStack.razor
@@ -8,7 +8,7 @@
                   Visible="@snackbarInfo.Visible"
                   Color="@snackbarInfo.Color"
                   Multiline="@Multiline"
-                  Interval="@Interval"
+                  Interval="@snackbarInfo.IntervalBeforeClose"
                   Closed="@(async (e)=> await OnSnackbarClosed(e.Key, e.CloseReason))">
             <SnackbarBody>
                 @if ( snackbarInfo.MessageTemplate != null )

--- a/Source/Extensions/Blazorise.Snackbar/SnackbarStack.razor.cs
+++ b/Source/Extensions/Blazorise.Snackbar/SnackbarStack.razor.cs
@@ -17,13 +17,14 @@ namespace Blazorise.Snackbar
 
         private class SnackbarInfo
         {
-            public SnackbarInfo( string key, string message, RenderFragment messageTemplate, SnackbarColor color, string actionButtonText )
+            public SnackbarInfo( string key, string message, RenderFragment messageTemplate, SnackbarColor color, string actionButtonText, double intervalBeforeClose )
             {
                 Key = key ?? Guid.NewGuid().ToString();
                 Message = message;
                 MessageTemplate = messageTemplate;
                 Color = color;
                 ActionButtonText = actionButtonText;
+                IntervalBeforeClose = intervalBeforeClose;
             }
 
             public string Key { get; }
@@ -37,6 +38,8 @@ namespace Blazorise.Snackbar
             public string ActionButtonText { get; }
 
             public bool Visible { get; } = true;
+
+            public double IntervalBeforeClose { get; set; }
         }
 
         private SnackbarStackLocation location = SnackbarStackLocation.Center;
@@ -60,14 +63,29 @@ namespace Blazorise.Snackbar
             Push( null, message, null, color, actionButtonText );
         }
 
+        public void Push( string message, double intervalBeforeClose, SnackbarColor color = SnackbarColor.None, string actionButtonText = null )
+        {
+            Push( null, message, null, intervalBeforeClose, color, actionButtonText );
+        }
+
         public void Push( RenderFragment messageTemplate, SnackbarColor color = SnackbarColor.None, string actionButtonText = null )
         {
             Push( null, null, messageTemplate, color, actionButtonText );
         }
 
+        public void Push( RenderFragment messageTemplate, double intervalBeforeClose, SnackbarColor color = SnackbarColor.None, string actionButtonText = null )
+        {
+            Push( null, null, messageTemplate, intervalBeforeClose, color, actionButtonText );
+        }
+
         public void Push( string key, string message, RenderFragment messageTemplate, SnackbarColor color = SnackbarColor.None, string actionButtonText = null )
         {
-            snackbarInfos.Add( new SnackbarInfo( key, message, messageTemplate, color, actionButtonText ) );
+            Push( key, message, messageTemplate, DefaultInterval, color, actionButtonText );
+        }
+
+        public void Push( string key, string message, RenderFragment messageTemplate, double intervalBeforeClose, SnackbarColor color = SnackbarColor.None, string actionButtonText = null )
+        {
+            snackbarInfos.Add( new SnackbarInfo( key, message, messageTemplate, color, actionButtonText, intervalBeforeClose ) );
 
             StateHasChanged();
         }
@@ -111,7 +129,7 @@ namespace Blazorise.Snackbar
         /// <summary>
         /// Defines the interval(in milliseconds) after which the snackbars will be automatically closed.
         /// </summary>
-        [Parameter] public double Interval { get; set; } = 3000;
+        [Parameter] public double DefaultInterval { get; set; } = 3000;
 
         /// <summary>
         /// Defines a text to show for snackbar action button. Leave as null to not show it!

--- a/docs/_docs/extensions/snackbar.md
+++ b/docs/_docs/extensions/snackbar.md
@@ -93,6 +93,8 @@ When you want to show multiple snackbars stacked on top of each other you can us
 ```html
 <Button Color="Color.Primary" Clicked="@(()=>snackbarStack.Push("Current time is: " + DateTime.Now, SnackbarColor.Info))">Primary</Button>
 
+<Button Color="Color.Primary" Clicked="@(()=>snackbarStack.Push(message: "Current time is: " + DateTime.Now, intervalBeforeClose: 10000, color: SnackbarColor.Info))">Primary</Button>
+
 <SnackbarStack @ref="snackbarStack" Location="SnackbarStackLocation.Right" />
 @code{
     SnackbarStack snackbarStack;
@@ -101,11 +103,11 @@ When you want to show multiple snackbars stacked on top of each other you can us
 
 ## Attributes
 
-| Name               | Type                                                                                     | Default      | Description                                                                                  |
-|--------------------|------------------------------------------------------------------------------------------|--------------|----------------------------------------------------------------------------------------------|
-| Location           | [SnackbarLocation]({{ "/docs/helpers/enums/#snackbarlocation" | relative_url }})         | `None`       | Defines the snackbar location.                                                               |
-| Color              | [SnackbarColor]({{ "/docs/helpers/colors/#snackbarcolor" | relative_url }})              | `None`       | Defines the snackbar color.                                                                  |
-| Visible            | bool                                                                                     | false        | Defines the visibility of snackbar.                                                          |
-| Multiline          | bool                                                                                     | false        | Allow snackbar to show multiple lines of text.                                               |
-| Interval           | double                                                                                   | 3000         | Defines the interval(in milliseconds) after which the snackbar will be automatically closed. |
-| Closed             | `EventCallback<SnackbarClosedEventArgs>`                                                 |              | Occurs after the snackbar has closed.                                                        |
+| Name               | Type                                                                                     | Default      | Description                                                                                                                                          |
+|--------------------|------------------------------------------------------------------------------------------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Location           | [SnackbarLocation]({{ "/docs/helpers/enums/#snackbarlocation" | relative_url }})         | `None`       | Defines the snackbar location.                                                                                                                       |
+| Color              | [SnackbarColor]({{ "/docs/helpers/colors/#snackbarcolor" | relative_url }})              | `None`       | Defines the snackbar color.                                                                                                                          |
+| Visible            | bool                                                                                     | false        | Defines the visibility of snackbar.                                                                                                                  |
+| Multiline          | bool                                                                                     | false        | Allow snackbar to show multiple lines of text.                                                                                                       |
+| DefaultInterval    | double                                                                                   | 3000         | Defines the interval (in milliseconds) after which the snackbar will be automatically closed by default (if no value is provided in the Push method) |
+| Closed             | `EventCallback<SnackbarClosedEventArgs>`                                                 |              | Occurs after the snackbar has closed.                                                                                                                |


### PR DESCRIPTION
Functionality for selecting the notification life interval when calling the Push method.

Add IntervalBeforeClose to SnackbarInfo;
Add intervalBeforeClose parameter to SnackbarStack Push methods;
Use SnackbarInfo.IntervalBeforeClose instead of SnackbarInfo.Interval in SnackbarStack.razor;
Rename SnackbarStack Interval to DefaultInterval;
Added documentation for intervals.