### PR TITLE
SnackbarStack selecting the notification life interval when calling the Push method

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Tests/ElementsPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/ElementsPage.razor
@@ -292,6 +292,48 @@
     </Column>
 </Row>
 <Row>
+    <Column>
+        <Card Margin="Margin.Is4.FromBottom">
+            <CardHeader>
+                <CardTitle>Stacked snackbars with custom intervals</CardTitle>
+            </CardHeader>
+            <CardBody>
+                <CardText>
+                    You can have a dynamicaly stacked snackbars with custom interval before close.
+                </CardText>
+            </CardBody>
+            <CardBody>
+                <Field Horizontal="true">
+                    <FieldLabel ColumnSize="ColumnSize.IsFull.OnTablet.Is2.OnDesktop">Interval</FieldLabel>
+                    <FieldBody ColumnSize="ColumnSize.IsFull.OnTablet.Is10.OnDesktop">
+                        <NumericEdit @bind-Value="this.intervalBeforeMsgClose" />
+                    </FieldBody>
+                </Field>
+                <Button Color="Color.Success" Clicked="@(()=>snackbarStack.PushAsync("Some success message! Timeout: " + intervalBeforeMsgClose, SnackbarColor.Success, options =>
+                                                         {
+                                                             options.CloseButtonIcon = "Ok";
+                                                             options.IntervalBeforeClose = intervalBeforeMsgClose;
+                                                         } ))">Show Success message</Button>
+                <Button Color="Color.Info" Clicked="@(()=>snackbarStack.PushAsync("Some info message! Timeout: " + intervalBeforeMsgClose, SnackbarColor.Info, options =>
+                                                         {
+                                                             options.CloseButtonIcon = "Ok";
+                                                             options.IntervalBeforeClose = intervalBeforeMsgClose;
+                                                         } ))">Show Info message</Button>
+                <Button Color="Color.Warning" Clicked="@(()=>snackbarStack.PushAsync("Some warning message! Timeout: " + intervalBeforeMsgClose, SnackbarColor.Warning, options =>
+                                                         {
+                                                             options.CloseButtonIcon = "Ok";
+                                                             options.IntervalBeforeClose = intervalBeforeMsgClose;
+                                                         } ))">Show Warning message</Button>
+                <Button Color="Color.Danger" Clicked="@(()=>snackbarStack.PushAsync("Some danger message! Timeout: " + intervalBeforeMsgClose, SnackbarColor.Danger, options =>
+                                                         {
+                                                             options.CloseButtonIcon = "Ok";
+                                                             options.IntervalBeforeClose = intervalBeforeMsgClose;
+                                                         } ))">Show Danger message</Button>
+            </CardBody>
+        </Card>
+    </Column>
+</Row>
+<Row>
     <Column ColumnSize="ColumnSize.Is12.OnMobile">
         <Jumbotron Background="Background.Primary" Margin="Margin.Is4.FromBottom">
             <JumbotronTitle Size="JumbotronTitleSize.Is4">Hello, world!</JumbotronTitle>
@@ -512,6 +554,8 @@
     Snackbar snackbarDark;
 
     SnackbarStack snackbarStack;
+
+    double intervalBeforeMsgClose = 2000;
 
     bool dismisableAlert1 = true;
     bool dismisableAlert2 = true;

--- a/Demos/Blazorise.Demo/Pages/Tests/ElementsPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/ElementsPage.razor
@@ -275,26 +275,6 @@
     <Column>
         <Card Margin="Margin.Is4.FromBottom">
             <CardHeader>
-                <CardTitle>Stacked snackbars</CardTitle>
-            </CardHeader>
-            <CardBody>
-                <CardText>
-                    You can have a dynamicaly stacked snackbars.
-                </CardText>
-            </CardBody>
-            <CardBody>
-                <Button Color="Color.Success" Clicked="@(()=>snackbarStack.PushAsync("Some success message!", "Hello", SnackbarColor.Success, (options) => { options.CloseButtonIcon = IconName.Times; options.ActionButtonText = "OK"; }))">Show Success message</Button>
-                <Button Color="Color.Info" Clicked="@(()=>snackbarStack.PushAsync("Some info message!", SnackbarColor.Info, (options) => { options.ActionButtonText = "Ok"; }))">Show Info message</Button>
-                <Button Color="Color.Warning" Clicked="@(()=>snackbarStack.PushAsync("Some warning message!", SnackbarColor.Warning, (options) => { options.ActionButtonText = "Ok"; }))">Show Warning message</Button>
-                <Button Color="Color.Danger" Clicked="@(()=>snackbarStack.PushAsync("Some danger message!", SnackbarColor.Danger, (options) => { options.ActionButtonText = "Dismiss"; }))">Show Danger message</Button>
-            </CardBody>
-        </Card>
-    </Column>
-</Row>
-<Row>
-    <Column>
-        <Card Margin="Margin.Is4.FromBottom">
-            <CardHeader>
                 <CardTitle>Stacked snackbars with custom intervals</CardTitle>
             </CardHeader>
             <CardBody>
@@ -304,31 +284,23 @@
             </CardBody>
             <CardBody>
                 <Field Horizontal="true">
-                    <FieldLabel ColumnSize="ColumnSize.IsFull.OnTablet.Is2.OnDesktop">Interval</FieldLabel>
+                    <FieldLabel ColumnSize="ColumnSize.IsFull.OnTablet.Is2.OnDesktop">Interval(ms)</FieldLabel>
                     <FieldBody ColumnSize="ColumnSize.IsFull.OnTablet.Is10.OnDesktop">
                         <NumericEdit @bind-Value="this.intervalBeforeMsgClose" />
                     </FieldBody>
                 </Field>
-                <Button Color="Color.Success" Clicked="@(()=>snackbarStack.PushAsync("Some success message! Timeout: " + intervalBeforeMsgClose, SnackbarColor.Success, options =>
-                                                         {
-                                                             options.CloseButtonIcon = "Ok";
-                                                             options.IntervalBeforeClose = intervalBeforeMsgClose;
-                                                         } ))">Show Success message</Button>
-                <Button Color="Color.Info" Clicked="@(()=>snackbarStack.PushAsync("Some info message! Timeout: " + intervalBeforeMsgClose, SnackbarColor.Info, options =>
-                                                         {
-                                                             options.CloseButtonIcon = "Ok";
-                                                             options.IntervalBeforeClose = intervalBeforeMsgClose;
-                                                         } ))">Show Info message</Button>
-                <Button Color="Color.Warning" Clicked="@(()=>snackbarStack.PushAsync("Some warning message! Timeout: " + intervalBeforeMsgClose, SnackbarColor.Warning, options =>
-                                                         {
-                                                             options.CloseButtonIcon = "Ok";
-                                                             options.IntervalBeforeClose = intervalBeforeMsgClose;
-                                                         } ))">Show Warning message</Button>
-                <Button Color="Color.Danger" Clicked="@(()=>snackbarStack.PushAsync("Some danger message! Timeout: " + intervalBeforeMsgClose, SnackbarColor.Danger, options =>
-                                                         {
-                                                             options.CloseButtonIcon = "Ok";
-                                                             options.IntervalBeforeClose = intervalBeforeMsgClose;
-                                                         } ))">Show Danger message</Button>
+                <Button Color="Color.Success" Clicked="@(()=>snackbarStack.PushAsync("Some success message! Timeout: " + intervalBeforeMsgClose, SnackbarColor.Success, options => { options.CloseButtonIcon = "Ok"; options.IntervalBeforeClose = intervalBeforeMsgClose; } ))">
+                    Show Success message
+                </Button>
+                <Button Color="Color.Info" Clicked="@(()=>snackbarStack.PushAsync("Some info message! Timeout: " + intervalBeforeMsgClose, SnackbarColor.Info, options => { options.CloseButtonIcon = "Ok"; options.IntervalBeforeClose = intervalBeforeMsgClose; } ))">
+                    Show Info message
+                </Button>
+                <Button Color="Color.Warning" Clicked="@(()=>snackbarStack.PushAsync("Some warning message! Timeout: " + intervalBeforeMsgClose, SnackbarColor.Warning, options => { options.CloseButtonIcon = "Ok"; options.IntervalBeforeClose = intervalBeforeMsgClose; } ))">
+                    Show Warning message
+                </Button>
+                <Button Color="Color.Danger" Clicked="@(()=>snackbarStack.PushAsync("Some danger message! Timeout: " + intervalBeforeMsgClose, SnackbarColor.Danger, options => { options.CloseButtonIcon = "Ok"; options.IntervalBeforeClose = intervalBeforeMsgClose; } ))">
+                    Show Danger message
+                </Button>
             </CardBody>
         </Card>
     </Column>

--- a/Source/Extensions/Blazorise.Snackbar/SnackbarOptions.cs
+++ b/Source/Extensions/Blazorise.Snackbar/SnackbarOptions.cs
@@ -51,7 +51,7 @@ namespace Blazorise.Snackbar
         public object ActionButtonIcon { get; set; }
 
         /// <summary>
-        /// Notification lifetime
+        /// Time in millisecond until snackbar is automatically closed.
         /// </summary>
         public double IntervalBeforeClose { get; set; }
     }

--- a/Source/Extensions/Blazorise.Snackbar/SnackbarOptions.cs
+++ b/Source/Extensions/Blazorise.Snackbar/SnackbarOptions.cs
@@ -49,5 +49,10 @@ namespace Blazorise.Snackbar
         /// Custom action button icon. Can be either enum <see cref="IconName"/> or string eg. "fa-times".
         /// </summary>
         public object ActionButtonIcon { get; set; }
+
+        /// <summary>
+        /// Notification lifetime
+        /// </summary>
+        public double IntervalBeforeClose { get; set; }
     }
 }

--- a/Source/Extensions/Blazorise.Snackbar/SnackbarStack.razor
+++ b/Source/Extensions/Blazorise.Snackbar/SnackbarStack.razor
@@ -8,7 +8,7 @@
                   Visible="@snackbarInfo.Visible"
                   Color="@snackbarInfo.Color"
                   Multiline="@Multiline"
-                  Interval="@Interval"
+                  Interval="@snackbarInfo.IntervalBeforeClose"
                   DelayCloseOnClick="@DelayCloseOnClick"
                   DelayCloseOnClickInterval="@DelayCloseOnClickInterval"
                   Closed="@(async (e)=> await OnSnackbarClosed(e.Key, e.CloseReason))">

--- a/Source/Extensions/Blazorise.Snackbar/SnackbarStack.razor.cs
+++ b/Source/Extensions/Blazorise.Snackbar/SnackbarStack.razor.cs
@@ -26,7 +26,8 @@ namespace Blazorise.Snackbar
                 object closeButtonIcon,
                 bool showActionButton,
                 string actionButtonText,
-                object actionButtonIcon )
+                object actionButtonIcon,
+                double intervalBeforeClose )
             {
                 Message = message;
                 Title = title;
@@ -39,6 +40,7 @@ namespace Blazorise.Snackbar
                 ShowActionButton = showActionButton;
                 ActionButtonText = actionButtonText;
                 ActionButtonIcon = actionButtonIcon;
+                IntervalBeforeClose = intervalBeforeClose;
             }
 
             public string Message { get; }
@@ -62,6 +64,8 @@ namespace Blazorise.Snackbar
             public string ActionButtonText { get; }
 
             public object ActionButtonIcon { get; }
+
+            public double IntervalBeforeClose { get; }
 
             public bool Visible { get; } = true;
         }
@@ -115,7 +119,8 @@ namespace Blazorise.Snackbar
                 snackbarOptions.CloseButtonIcon,
                 snackbarOptions.ShowActionButton,
                 snackbarOptions.ActionButtonText,
-                snackbarOptions.ActionButtonIcon ) );
+                snackbarOptions.ActionButtonIcon,
+                snackbarOptions.IntervalBeforeClose ) );
 
             return InvokeAsync( () => StateHasChanged() );
         }
@@ -138,6 +143,7 @@ namespace Blazorise.Snackbar
             {
                 Key = IdGenerator.Generate,
                 ShowCloseButton = true,
+                IntervalBeforeClose = DefaultInterval
             };
         }
 
@@ -166,12 +172,12 @@ namespace Blazorise.Snackbar
         [Parameter] public bool Multiline { get; set; }
 
         /// <summary>
-        /// Defines the interval(in milliseconds) after which the snackbars will be automatically closed.
+        /// Defines the default interval (in milliseconds) after which the snackbars will be automatically closed (used if IntervalBeforeClose is not set on PushAsync call).
         /// </summary>
-        [Parameter] public double Interval { get; set; } = 5000;
+        [Parameter] public double DefaultInterval { get; set; } = 5000;
 
         /// <summary>
-        /// If clicked on snackbar, a close action will be delayed by increasing the <see cref="Interval"/> time.
+        /// If clicked on snackbar, a close action will be delayed by increasing the <see cref="DefaultInterval"/> time.
         /// </summary>
         [Parameter] public bool DelayCloseOnClick { get; set; }
 

--- a/docs/_docs/extensions/snackbar.md
+++ b/docs/_docs/extensions/snackbar.md
@@ -91,7 +91,9 @@ You can also define variant [colors]({{ "/docs/helpers/colors/#snackbarcolor" | 
 When you want to show multiple snackbars stacked on top of each other you can use a wrapper component `SnackbarStack`.
 
 ```html
-<Button Color="Color.Primary" Clicked="@(()=>snackbarStack.Push("Current time is: " + DateTime.Now, SnackbarColor.Info))">Primary</Button>
+<Button Color="Color.Primary" Clicked="@(()=>snackbarStack.PushAsync("Current time is: " + DateTime.Now, SnackbarColor.Info))">Primary</Button>
+
+<Button Color="Color.Info" Clicked="@(()=>snackbarStack.PushAsync("Some info message! Timeout: " + intervalBeforeMsgClose, SnackbarColor.Info, options => { IntervalBeforeClose = intervalBeforeMsgClose; } ))">Show Info</Button>
 
 <SnackbarStack @ref="snackbarStack" Location="SnackbarStackLocation.Right" />
 @code{
@@ -101,13 +103,13 @@ When you want to show multiple snackbars stacked on top of each other you can us
 
 ## Attributes
 
-| Name                      | Type                                                                                     | Default      | Description                                                                                  |
-|---------------------------|------------------------------------------------------------------------------------------|--------------|----------------------------------------------------------------------------------------------|
-| Location                  | [SnackbarLocation]({{ "/docs/helpers/enums/#snackbarlocation" | relative_url }})         | `None`       | Defines the snackbar location.                                                               |
-| Color                     | [SnackbarColor]({{ "/docs/helpers/colors/#snackbarcolor" | relative_url }})              | `None`       | Defines the snackbar color.                                                                  |
-| Visible                   | bool                                                                                     | false        | Defines the visibility of snackbar.                                                          |
-| Multiline                 | bool                                                                                     | false        | Allow snackbar to show multiple lines of text.                                               |
-| Interval                  | double                                                                                   | 5000         | Defines the interval(in milliseconds) after which the snackbar will be automatically closed. |
-| DelayCloseOnClick         | bool                                                                                     | false        | If clicked on snackbar, a close action will be delayed by increasing the Interval time.      |
-| DelayCloseOnClickInterval | double                                                                                   | 'null'       | Defines the interval(in milliseconds) by which the snackbar will be delayed from closing.    |
-| Closed                    | `EventCallback<SnackbarClosedEventArgs>`                                                 |              | Occurs after the snackbar has closed.                                                        |
+| Name                      | Type                                                                                     | Default      | Description                                                                                                                                      |
+|---------------------------|------------------------------------------------------------------------------------------|--------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| Location                  | [SnackbarLocation]({{ "/docs/helpers/enums/#snackbarlocation" | relative_url }})         | `None`       | Defines the snackbar location.                                                                                                                   |
+| Color                     | [SnackbarColor]({{ "/docs/helpers/colors/#snackbarcolor" | relative_url }})              | `None`       | Defines the snackbar color.                                                                                                                      |
+| Visible                   | bool                                                                                     | false        | Defines the visibility of snackbar.                                                                                                              |
+| Multiline                 | bool                                                                                     | false        | Allow snackbar to show multiple lines of text.                                                                                                   |
+| DefaultInterval           | double                                                                                   | 5000         | Defines the interval (in milliseconds) after which the snackbar will be automatically closed.                                                    |
+| DelayCloseOnClick         | bool                                                                                     | false        | If clicked on snackbar, a close action will be delayed by increasing the DefaultInterval time (used if no value is provided in the Push method). |
+| DelayCloseOnClickInterval | double                                                                                   | 'null'       | Defines the interval(in milliseconds) by which the snackbar will be delayed from closing.                                                        |
+| Closed                    | `EventCallback<SnackbarClosedEventArgs>`                                                 |              | Occurs after the snackbar has closed.                                                                                                            |

--- a/docs/_docs/extensions/snackbar.md
+++ b/docs/_docs/extensions/snackbar.md
@@ -98,6 +98,7 @@ When you want to show multiple snackbars stacked on top of each other you can us
 <SnackbarStack @ref="snackbarStack" Location="SnackbarStackLocation.Right" />
 @code{
     SnackbarStack snackbarStack;
+    int intervalBeforeMsgClose = 2000;
 }
 ```
 


### PR DESCRIPTION
SnackbarStack selecting the notification life interval when calling the Push method.

Add IntervalBeforeClose to SnackbarInfo and SnackbarOptions;
Use SnackbarInfo.IntervalBeforeClose instead of SnackbarInfo.Interval in SnackbarStack.razor;
Rename SnackbarStack Interval to DefaultInterval;
Changed documentation for intervals.