### PR TITLE
BarLink clicked event fired

### DIFF
--- a/Source/Blazorise.AntDesign/BarDropdownItem.razor
+++ b/Source/Blazorise.AntDesign/BarDropdownItem.razor
@@ -1,15 +1,6 @@
 ﻿@inherits Blazorise.BarDropdownItem
 <li id="@ElementId" class="@ClassNames" role="menuitem" @attributes="@Attributes">
-    @if ( To != null )
-    {
-        <Blazorise.Link Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Attributes="@Attributes">
-            @ChildContent
-        </Blazorise.Link>
-    }
-    else
-    {
-        <a title="@Title" style="@StyleNames" @onclick="@ClickHandler" @attributes="@Attributes">
-            @ChildContent
-        </a>
-    }
+    <Blazorise.Link Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@Attributes">
+        @ChildContent
+    </Blazorise.Link>
 </li>

--- a/Source/Blazorise.AntDesign/BarLink.razor
+++ b/Source/Blazorise.AntDesign/BarLink.razor
@@ -1,13 +1,4 @@
 ﻿@inherits Blazorise.BarLink
-@if ( To != null )
-{
-    <Blazorise.Link ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Attributes="@Attributes">
-        <span>@ChildContent</span>
-    </Blazorise.Link>
-}
-else
-{
-    <a id="@ElementId" class="@ClassNames" style="@StyleNames" title="@Title" @onclick="@ClickHandler" @attributes="@Attributes">
-        <span>@ChildContent</span>
-    </a>
-}
+<Blazorise.Link ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Clicked="@ClickHandler" Target="@Target" Title="@Title" Match="@Match" Attributes="@Attributes">
+    <span>@ChildContent</span>
+</Blazorise.Link>

--- a/Source/Blazorise.AntDesign/BreadcrumbLink.razor
+++ b/Source/Blazorise.AntDesign/BreadcrumbLink.razor
@@ -6,18 +6,9 @@
     }
     else
     {
-        @if ( To != null )
-        {
-            <Blazorise.Link ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Attributes="@Attributes">
-                @ChildContent
-            </Blazorise.Link>
-        }
-        else
-        {
-            <a id="@ElementId" class="@ClassNames" style="@StyleNames" title="@Title" @onclick="@ClickHandler" @attributes="@Attributes">
-                @ChildContent
-            </a>
-        }
+        <Blazorise.Link ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@Attributes">
+            @ChildContent
+        </Blazorise.Link>
     }
 </span>
 <span class="ant-breadcrumb-separator">/</span>

--- a/Source/Blazorise.Bulma/BreadcrumbLink.razor
+++ b/Source/Blazorise.Bulma/BreadcrumbLink.razor
@@ -1,13 +1,4 @@
 ﻿@inherits Blazorise.BreadcrumbLink
-@if ( To != null )
-{
-    <Blazorise.Link ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Attributes="@Attributes">
-        @ChildContent
-    </Blazorise.Link>
-}
-else
-{
-    <a id="@ElementId" class="@ClassNames" style="@StyleNames" title="@Title" @onclick="@ClickHandler" @attributes="@Attributes">
-        @ChildContent
-    </a>
-}
+<Blazorise.Link ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@Attributes">
+    @ChildContent
+</Blazorise.Link>

--- a/Source/Blazorise/Components/Bar/BarDropdownItem.razor
+++ b/Source/Blazorise/Components/Bar/BarDropdownItem.razor
@@ -1,14 +1,5 @@
 ﻿@namespace Blazorise
 @inherits BaseComponent
-@if ( To != null )
-{
-    <Blazorise.Link ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Attributes="@Attributes">
-        @ChildContent
-    </Blazorise.Link>
-}
-else
-{
-    <a id="@ElementId" class="@ClassNames" style="@StyleNames" title="@Title" @onclick="@ClickHandler" @attributes="@Attributes">
-        @ChildContent
-    </a>
-}
+<Blazorise.Link ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@Attributes">
+    @ChildContent
+</Blazorise.Link>

--- a/Source/Blazorise/Components/Bar/BarLink.razor
+++ b/Source/Blazorise/Components/Bar/BarLink.razor
@@ -1,14 +1,5 @@
 ﻿@namespace Blazorise
 @inherits BaseComponent
-@if ( To != null )
-{
-    <Blazorise.Link ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Clicked="@Clicked" Target="@Target" Title="@Title" Match="@Match" Attributes="@Attributes">
-        @ChildContent
-    </Blazorise.Link>
-}
-else
-{
-    <a id="@ElementId" class="@ClassNames" style="@StyleNames" title="@Title" @onclick="@ClickHandler" @attributes="@Attributes">
-        @ChildContent
-    </a>
-}
+<Blazorise.Link ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@Attributes">
+    @ChildContent
+</Blazorise.Link>

--- a/Source/Blazorise/Components/Bar/BarLink.razor
+++ b/Source/Blazorise/Components/Bar/BarLink.razor
@@ -2,7 +2,7 @@
 @inherits BaseComponent
 @if ( To != null )
 {
-    <Blazorise.Link ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Attributes="@Attributes">
+    <Blazorise.Link ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Clicked="@Clicked" Target="@Target" Title="@Title" Match="@Match" Attributes="@Attributes">
         @ChildContent
     </Blazorise.Link>
 }

--- a/Source/Blazorise/Components/Breadcrumb/BreadcrumbLink.razor
+++ b/Source/Blazorise/Components/Breadcrumb/BreadcrumbLink.razor
@@ -6,16 +6,7 @@
 }
 else
 {
-    @if ( To != null )
-    {
-        <Blazorise.Link ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Attributes="@Attributes">
-            @ChildContent
-        </Blazorise.Link>
-    }
-    else
-    {
-        <a id="@ElementId" class="@ClassNames" style="@StyleNames" title="@Title" @onclick="@ClickHandler" @attributes="@Attributes">
-            @ChildContent
-        </a>
-    }
+    <Blazorise.Link ElementId="@ElementId" Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@Attributes">
+        @ChildContent
+    </Blazorise.Link>
 }

--- a/Source/Extensions/Blazorise.Sidebar/SidebarLink.razor
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarLink.razor
@@ -1,13 +1,4 @@
 ﻿@inherits BaseComponent
-@if ( To != null )
-{
-    <Blazorise.Link Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Attributes="@Attributes">
-        @ChildContent
-    </Blazorise.Link>
-}
-else
-{
-    <a class="@ClassNames" style="@StyleNames" @onclick="@ClickHandler" data-toggle="@DataToggle" aria-expanded="@AriaExpanded" title="@Title" @attributes="@Attributes">
-        @ChildContent
-    </a>
-}
+<Blazorise.Link Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@Attributes">
+    @ChildContent
+</Blazorise.Link>

--- a/Tests/Blazorise.Tests/Components/BarLinkComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/BarLinkComponentTest.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using AngleSharp.Dom;
-using BasicTestApp.Client;
 using Blazorise.Tests.Helpers;
 using Blazorise.Tests.TestServices;
 using Bunit;
@@ -14,8 +12,8 @@ namespace Blazorise.Tests.Components
     {
         public BarLinkComponentTest()
         {
-            var testServices = new TestServiceProvider( Services.AddSingleton<NavigationManager, TestNavigationManager>());
-            BlazoriseConfig.AddBootstrapProviders( testServices ) ;
+            var testServices = new TestServiceProvider( Services.AddSingleton<NavigationManager, TestNavigationManager>() );
+            BlazoriseConfig.AddBootstrapProviders( testServices );
         }
 
         [Fact]
@@ -23,38 +21,39 @@ namespace Blazorise.Tests.Components
         {
             // setup
             bool wasClicked = false;
-            var testCallback = new EventCallback( null, (Action)( () => 
-                wasClicked = true ));
+            var testCallback = new EventCallback( null, (Action)( () =>
+                wasClicked = true ) );
 
             // test
-            var comp = RenderComponent<BarLink>(builder => 
+            var comp = RenderComponent<BarLink>( builder =>
                 builder
-                    .Add( p => p.Clicked, testCallback ));
+                    .Add( p => p.Clicked, testCallback ) );
+
             comp.Find( "a" ).Click();
 
             // validate
             Assert.True( wasClicked );
         }
-        
+
         [Fact]
         public void CanRaiseClicked_WithToParameterSet()
         {
             // setup
             bool wasClicked = false;
-            var testCallback = new EventCallback( null, (Action)( () => 
-                wasClicked = true ));
+            var testCallback = new EventCallback( null, (Action)( () =>
+                wasClicked = true ) );
+
             // test
-            var comp = RenderComponent<BarLink>(builder => 
+            var comp = RenderComponent<BarLink>( builder =>
                 builder
-                    .Add( p => p.To, "test")
-                    .Add( p => p.Clicked, testCallback ));
-            
+                    .Add( p => p.To, "test" )
+                    .Add( p => p.Clicked, testCallback ) );
+
             var link = comp.FindComponent<Link>();
-            var a = link.Find( "a" );
-            a.Click();
+            link.Find( "a" ).Click();
 
             // validate
-            Assert.Equal(link.Instance.Clicked, testCallback); 
+            Assert.Equal( link.Instance.Clicked, testCallback );
             Assert.True( wasClicked );
         }
     }

--- a/Tests/Blazorise.Tests/Components/BarLinkComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/BarLinkComponentTest.cs
@@ -53,7 +53,6 @@ namespace Blazorise.Tests.Components
             link.Find( "a" ).Click();
 
             // validate
-            Assert.Equal( link.Instance.Clicked, testCallback );
             Assert.True( wasClicked );
         }
     }

--- a/Tests/Blazorise.Tests/Components/BarLinkComponentTest.cs
+++ b/Tests/Blazorise.Tests/Components/BarLinkComponentTest.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using AngleSharp.Dom;
+using BasicTestApp.Client;
+using Blazorise.Tests.Helpers;
+using Blazorise.Tests.TestServices;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Blazorise.Tests.Components
+{
+    public class BarLinkComponentTest : TestContext
+    {
+        public BarLinkComponentTest()
+        {
+            var testServices = new TestServiceProvider( Services.AddSingleton<NavigationManager, TestNavigationManager>());
+            BlazoriseConfig.AddBootstrapProviders( testServices ) ;
+        }
+
+        [Fact]
+        public void CanRaiseClicked_WithoutToParameterSet()
+        {
+            // setup
+            bool wasClicked = false;
+            var testCallback = new EventCallback( null, (Action)( () => 
+                wasClicked = true ));
+
+            // test
+            var comp = RenderComponent<BarLink>(builder => 
+                builder
+                    .Add( p => p.Clicked, testCallback ));
+            comp.Find( "a" ).Click();
+
+            // validate
+            Assert.True( wasClicked );
+        }
+        
+        [Fact]
+        public void CanRaiseClicked_WithToParameterSet()
+        {
+            // setup
+            bool wasClicked = false;
+            var testCallback = new EventCallback( null, (Action)( () => 
+                wasClicked = true ));
+            // test
+            var comp = RenderComponent<BarLink>(builder => 
+                builder
+                    .Add( p => p.To, "test")
+                    .Add( p => p.Clicked, testCallback ));
+            
+            var link = comp.FindComponent<Link>();
+            var a = link.Find( "a" );
+            a.Click();
+
+            // validate
+            Assert.Equal(link.Instance.Clicked, testCallback); 
+            Assert.True( wasClicked );
+        }
+    }
+}

--- a/Tests/Blazorise.Tests/TestServices/TestNavigationManager.cs
+++ b/Tests/Blazorise.Tests/TestServices/TestNavigationManager.cs
@@ -5,8 +5,8 @@ namespace Blazorise.Tests.TestServices
 {
     public class TestNavigationManager : NavigationManager
     {
-        public TestNavigationManager() => Initialize("https://www.example.com/", "https://www.example.com/base");
-        
+        public TestNavigationManager() => Initialize( "https://www.example.com/", "https://www.example.com/base" );
+
         protected override void NavigateToCore( string uri, bool forceLoad )
         {
             throw new NotImplementedException();

--- a/Tests/Blazorise.Tests/TestServices/TestNavigationManager.cs
+++ b/Tests/Blazorise.Tests/TestServices/TestNavigationManager.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Microsoft.AspNetCore.Components;
+
+namespace Blazorise.Tests.TestServices
+{
+    public class TestNavigationManager : NavigationManager
+    {
+        public TestNavigationManager() => Initialize("https://www.example.com/", "https://www.example.com/base");
+        
+        protected override void NavigateToCore( string uri, bool forceLoad )
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
I've added a simple `Clicked` event firing.

As you can see I've had to add `TestNavigationManager` class to Tests. It was because the `Link` component has `NavigationManager` injected using `@Inject` and there wasn't any registered. My implementation of `TestNavigationManager` was based on Microsoft implementation in Blazor test. You can find it [here](https://github.com/dotnet/aspnetcore/blob/2588e246e5ca469603d3253225a5dcecda45a1cd/src/Components/WebAssembly/WebAssembly.Authentication/test/WebAssemblyAuthenticationServiceCollectionExtensionsTests.cs#L440).