### PR TITLE
Fix bug when ButtonRowTemplate is null

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -6,7 +6,7 @@
 <CascadingValue Value=this>
     @if ( IsPagerVisible && ( PagerPosition == DataGridPagerPosition.Top || PagerPosition == DataGridPagerPosition.TopAndBottom ) )
     {
-        <_DataGridPagination TItem="TItem" ButtonRowTemplate="@ButtonRowTemplate" PaginationContext="@PaginationContext" PaginationTemplates="@PaginationTemplates" OnPaginationItemClick="@OnPaginationItemClick" New="OnNewCommand" Edit="@OnEditCommand" Delete="@OnDeleteCommand" SelectedRow="@SelectedRow" ClearFilter="@OnClearFilterCommand" />
+        <_DataGridPagination TItem="TItem" PaginationContext="@PaginationContext" PaginationTemplates="@PaginationTemplates" OnPaginationItemClick="@OnPaginationItemClick" New="@OnNewCommand" Edit="@OnEditCommand" Delete="@OnDeleteCommand" SelectedRow="@SelectedRow" ClearFilter="@OnClearFilterCommand" />
     }
     <Table ElementId="@ElementId" Class="@Class" Style="@Style" Margin="@Margin" Padding="@Padding" Striped="@Striped" Bordered="@Bordered" Borderless="@Borderless" Hoverable="@Hoverable" Narrow="@Narrow" Responsive="@Responsive">
         <TableHeader>
@@ -156,7 +156,7 @@
     </Table>
     @if ( IsPagerVisible && ( PagerPosition == DataGridPagerPosition.Bottom || PagerPosition == DataGridPagerPosition.TopAndBottom ) )
     {
-        <_DataGridPagination TItem="TItem" ButtonRowTemplate="@ButtonRowTemplate" PaginationContext="@PaginationContext" PaginationTemplates="@PaginationTemplates" OnPaginationItemClick="@OnPaginationItemClick" New="OnNewCommand" Edit="@OnEditCommand" Delete="@OnDeleteCommand" SelectedRow="@SelectedRow" ClearFilter="@OnClearFilterCommand" />
+        <_DataGridPagination TItem="TItem" PaginationContext="@PaginationContext" PaginationTemplates="@PaginationTemplates" OnPaginationItemClick="@OnPaginationItemClick" New="@OnNewCommand" Edit="@OnEditCommand" Delete="@OnDeleteCommand" SelectedRow="@SelectedRow" ClearFilter="@OnClearFilterCommand" />
     }
     @if ( editItem != null && EditMode == DataGridEditMode.Popup )
     {

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridPagination.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridPagination.razor.cs
@@ -67,6 +67,11 @@ namespace Blazorise.DataGrid
 
         #region Properties
 
+        /// <summary>
+        /// Gets or sets content of button row of pager.
+        /// </summary>
+        public RenderFragment<ButtonRowContext<TItem>> ButtonRowTemplate => ParentDataGrid?.ButtonRowTemplate;
+
         [Inject] protected ITextLocalizerService LocalizerService { get; set; }
 
         [Inject] protected ITextLocalizer<DataGrid<TItem>> Localizer { get; set; }
@@ -131,11 +136,6 @@ namespace Blazorise.DataGrid
         /// Activates the clear filter command.
         /// </summary>
         [Parameter] public EventCallback ClearFilter { get; set; }
-
-        /// <summary>
-        /// Gets or sets content of button row of pager.
-        /// </summary>
-        [Parameter] public RenderFragment<ButtonRowContext<TItem>> ButtonRowTemplate { get; set; }
 
         /// <summary>
         /// Gets or sets content of first button of pager.


### PR DESCRIPTION
When RenderFragment is passed as a parameter and it is `null` it will raise an exception. This PR fixes it.

@David-Moreira I noticed it only on production 😅