### PR TITLE
NumericEdit Min and Max fix

### DIFF
--- a/Source/Blazorise/wwwroot/blazorise.js
+++ b/Source/Blazorise/wwwroot/blazorise.js
@@ -351,7 +351,7 @@ window.blazorise = {
                 selection = this.carret();
 
             if (value = value.substring(0, selection[0]) + currentValue + value.substring(selection[1]), !!this.regex().test(value)) {
-                return value = (value || "").replace(this.separator, "."), value === "-" && this.min < 0 || value >= this.min && value <= this.max;
+                return value = (value || "").replace(this.separator, ".");
             }
 
             return false;

--- a/Tests/BasicTestApp.Client/NumericEditComponent.razor
+++ b/Tests/BasicTestApp.Client/NumericEditComponent.razor
@@ -59,7 +59,16 @@
 
     <span>The Value should update automatically as you type in the numeric field</span>
 
-    <span id="decimal-separator-with-comma-result">@decimalSeparator2.ToString( System.Globalization.CultureInfo.GetCultureInfo( "hr" ))</span>
+    <span id="decimal-separator-with-comma-result">@decimalSeparator2.ToString( System.Globalization.CultureInfo.GetCultureInfo( "hr" ) )</span>
+</p>
+
+<h2>Min And Max</h2>
+<p id="decimal-min-max-non-nullable">
+    <NumericEdit id="decimal-min-max-non-nullable-numeric" TValue="decimal" @bind-Value="@minMax1" Min="10" Max="20" />
+
+    <span>The Value should update automatically as you type in the numeric field</span>
+
+    <span id="decimal-min-max-non-nullable-result">@minMax1.ToString( System.Globalization.CultureInfo.InvariantCulture )</span>
 </p>
 @code{
     int intValue;
@@ -73,4 +82,6 @@
 
     decimal decimalSeparator1 = 42.5m;
     decimal decimalSeparator2 = 42.5m;
+
+    decimal minMax1 = 0;
 }

--- a/Tests/Blazorise.E2ETests/NumericEditTest.cs
+++ b/Tests/Blazorise.E2ETests/NumericEditTest.cs
@@ -159,5 +159,39 @@ namespace Blazorise.E2ETests
             numeric.SendKeys( ",3" );
             WaitAssert.Equal( "42,3", () => result.Text );
         }
+
+        [Fact]
+        public void CanTypeMinMax()
+        {
+            var paragraph = Browser.FindElement( By.Id( "decimal-min-max-non-nullable" ) );
+            var numeric = paragraph.FindElement( By.TagName( "input" ) );
+            var result = paragraph.FindElement( By.Id( "decimal-min-max-non-nullable-result" ) );
+
+            WaitAssert.Equal( "0", () => result.Text );
+
+            numeric.SendKeys( "2" );
+            WaitAssert.Equal( "2", () => result.Text );
+
+            result.Click(); // leave input by clicking on other element so that onblur can happen
+            WaitAssert.Equal( "10", () => result.Text );
+
+            numeric.Clear();
+            numeric.SendKeys( "15" );
+            WaitAssert.Equal( "15", () => result.Text );
+            result.Click();
+            WaitAssert.Equal( "15", () => result.Text );
+
+            numeric.Clear();
+            numeric.SendKeys( "21" );
+            WaitAssert.Equal( "21", () => result.Text );
+            result.Click();
+            WaitAssert.Equal( "20", () => result.Text );
+
+            numeric.Clear();
+            numeric.SendKeys( "0" );
+            WaitAssert.Equal( "0", () => result.Text );
+            result.Click();
+            WaitAssert.Equal( "0", () => result.Text );
+        }
     }
 }


### PR DESCRIPTION
resolves #1737

With this feature now it is possible to write any valid number but once input loses focus it revalidate against Min and Max and then adjust the value.

It works good but the only problem with this solution is that `ValueChanged` will be called two times. This is something that can be fixed sometime in the future in case it is much of a problem.