### PR TITLE
Add validation to Autocomplete component

### DIFF
--- a/Source/Blazorise/Base/BaseInputComponent.razor.cs
+++ b/Source/Blazorise/Base/BaseInputComponent.razor.cs
@@ -1,4 +1,5 @@
 ﻿#region Using directives
+using System;
 using System.Threading.Tasks;
 using Blazorise.Extensions;
 using Microsoft.AspNetCore.Components;
@@ -247,6 +248,14 @@ namespace Blazorise
         }
 
         /// <summary>
+        /// Forces the <see cref="Validation"/>(if any is used) to re-validate with the new custom or internal value.
+        /// </summary>
+        public void Revalidate()
+        {
+            ParentValidation?.NotifyInputChanged<TValue>( default );
+        }
+
+        /// <summary>
         /// Handler for validation status change event.
         /// </summary>
         /// <param name="sender">Object that raised the event.</param>
@@ -265,7 +274,9 @@ namespace Blazorise
         protected override bool ShouldAutoGenerateId => true;
 
         /// <inheritdoc/>
-        public virtual object ValidationValue => InternalValue;
+        public virtual object ValidationValue => CustomValidationValue != null
+            ? CustomValidationValue.Invoke()
+            : InternalValue;
 
         /// <summary>
         /// Returns true if input belong to a <see cref="FieldBody"/>.
@@ -418,6 +429,16 @@ namespace Blazorise
         /// If defined, indicates that its element can be focused and can participates in sequential keyboard navigation.
         /// </summary>
         [Parameter] public int? TabIndex { get; set; }
+
+        /// <summary>
+        /// Used to provide custom validation value on which the validation will be processed with
+        /// the <see cref="Validation.Validator"/> handler.
+        /// </summary>
+        /// <remarks>
+        /// Should be used carefully as it's only meant for some special cases when input is used
+        /// in a wrapper component, like Autocomplete or SelectList.
+        /// </remarks>
+        [Parameter] public Func<TValue> CustomValidationValue { get; set; }
 
         /// <summary>
         /// Parent validation container.

--- a/Source/Blazorise/Components/Validation/ValidationRule.cs
+++ b/Source/Blazorise/Components/Validation/ValidationRule.cs
@@ -127,6 +127,12 @@ namespace Blazorise
         /// <param name="e"></param>
         public static void IsLowercase( ValidatorEventArgs e ) => e.Status = IsLowercase( e.Value as string ) ? ValidationStatus.Success : ValidationStatus.Error;
 
+        /// <summary>
+        /// Empty validator.
+        /// </summary>
+        /// <param name="e"></param>
+        public static void None( ValidatorEventArgs e ) => e.Status = ValidationStatus.None;
+
         #endregion
     }
 }

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor
@@ -1,7 +1,29 @@
 ﻿@typeparam TItem
 @typeparam TValue
-<Dropdown @ref="dropdownRef" ElementId="@ElementId" Class="@DropdownClassNames" Style="@Style" Attributes="@Attributes" Visible="@DropdownVisible">
-    <TextEdit @ref="@textEditRef" Role="TextRole.Search" Text="@SelectedText" TextChanged="@OnTextChangedHandler" Placeholder="@Placeholder" Size="@Size" Disabled="@Disabled" TabIndex="@TabIndex" KeyDown="@OnTextKeyDownHandler" FocusIn="@OnTextFocusInHandler" Blur="@OnTextBlurHandler" ChangeTextOnKeyPress="@ChangeTextOnKeyPress" DelayTextOnKeyPress="@DelayTextOnKeyPress" DelayTextOnKeyPressInterval="@DelayTextOnKeyPressInterval" />
+<Dropdown @ref="@dropdownRef" ElementId="@ElementId" Class="@DropdownClassNames" Style="@Style" Attributes="@Attributes" Visible="@DropdownVisible">
+    <Validation Validator="@(Validator ?? ValidationRule.None)">
+        <TextEdit @ref="@textEditRef"
+                  Role="TextRole.Search"
+                  Text="@SelectedText"
+                  TextChanged="@OnTextChangedHandler"
+                  Placeholder="@Placeholder"
+                  Size="@Size"
+                  Disabled="@Disabled"
+                  TabIndex="@TabIndex"
+                  KeyDown="@OnTextKeyDownHandler"
+                  FocusIn="@OnTextFocusInHandler"
+                  Blur="@OnTextBlurHandler"
+                  ChangeTextOnKeyPress="@ChangeTextOnKeyPress"
+                  DelayTextOnKeyPress="@DelayTextOnKeyPress"
+                  DelayTextOnKeyPressInterval="@DelayTextOnKeyPressInterval"
+                  CustomValidationValue="@(()=>SelectedValue?.ToString())">
+            <Feedback>
+                <ValidationError />
+                <ValidationSuccess />
+                <ValidationNone />
+            </Feedback>
+        </TextEdit>
+    </Validation>
     <DropdownMenu>
         @if ( DropdownVisible )
         {

--- a/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
+++ b/Source/Extensions/Blazorise.Components/Autocomplete.razor.cs
@@ -152,6 +152,8 @@ namespace Blazorise.Components
 
             await SelectedValueChanged.InvokeAsync( SelectedValue );
             await SearchChanged.InvokeAsync( CurrentSearch );
+
+            textEditRef?.Revalidate();
         }
 
         private void FilterData()
@@ -398,6 +400,11 @@ namespace Blazorise.Components
         /// If defined, indicates that its element can be focused and can participates in sequential keyboard navigation.
         /// </summary>
         [Parameter] public int? TabIndex { get; set; }
+
+        /// <summary>
+        /// Validation handler used to validate selected value.
+        /// </summary>
+        [Parameter] public Action<ValidatorEventArgs> Validator { get; set; }
 
         /// <summary>
         /// Captures all the custom attribute that are not part of Blazorise component.

--- a/docs/_docs/extensions/autocomplete.md
+++ b/docs/_docs/extensions/autocomplete.md
@@ -61,19 +61,20 @@ Install-Package Blazorise.Components
 
 ## Attributes
 
-| Name                          | Type               | Default      | Description                                                                                           |
-|-------------------------------|--------------------|--------------|-------------------------------------------------------------------------------------------------------|
-| TItem                         | generic            |              | Model data type.                                                                                      |
-| Data                          | IEnumerable<TItem> |              | Data used for the search.                                                                             |
-| TextField                     | Func               |              | Selector for the display name field.                                                                  |
-| ValueField                    | Func               |              | Selector for the value field.                                                                         |
-| SelectedValue                 | object             |              | Currently selected value.                                                                             |
-| SelectedValueChanged          | event              |              | Raises an event after the selected value has changed.                                                 |
-| SearchChanged                 | event              |              | Occurs on every search text change.                                                                   |
-| Placeholder                   | string             |              | Placeholder for the empty search field.                                                               |
-| MinLength                     | int                | 1            | Minimum number of character needed to start search.                                                   |
-| Filter                        | enum               | StartsWith   | Filter method used to search the data.                                                                |
-| Disabled                      | boolean            | false        | Disable the input field.                                                                              |
-| ChangeTextOnKeyPress          | `bool?`            |  null        | If true the text in will be changed after each key press (overrides global settings).                 |
-| DelayTextOnKeyPress           | `bool?`            |  null        | If true the entered text will be slightly delayed before submitting it to the internal value.         |
-| DelayTextOnKeyPressInterval   | `int?`             |  null        | Interval in milliseconds that entered text will be delayed from submitting to the internal value.     |
+| Name                          | Type                          | Default      | Description                                                                                           |
+|-------------------------------|-------------------------------|--------------|-------------------------------------------------------------------------------------------------------|
+| TItem                         | generic                       |              | Model data type.                                                                                      |
+| Data                          | IEnumerable<TItem>            |              | Data used for the search.                                                                             |
+| TextField                     | Func                          |              | Selector for the display name field.                                                                  |
+| ValueField                    | Func                          |              | Selector for the value field.                                                                         |
+| SelectedValue                 | object                        |              | Currently selected value.                                                                             |
+| SelectedValueChanged          | event                         |              | Raises an event after the selected value has changed.                                                 |
+| SearchChanged                 | event                         |              | Occurs on every search text change.                                                                   |
+| Placeholder                   | string                        |              | Placeholder for the empty search field.                                                               |
+| MinLength                     | int                           | 1            | Minimum number of character needed to start search.                                                   |
+| Filter                        | enum                          | StartsWith   | Filter method used to search the data.                                                                |
+| Disabled                      | boolean                       | false        | Disable the input field.                                                                              |
+| ChangeTextOnKeyPress          | `bool?`                       |  null        | If true the text in will be changed after each key press (overrides global settings).                 |
+| DelayTextOnKeyPress           | `bool?`                       |  null        | If true the entered text will be slightly delayed before submitting it to the internal value.         |
+| DelayTextOnKeyPressInterval   | `int?`                        |  null        | Interval in milliseconds that entered text will be delayed from submitting to the internal value.     |
+| Validator                     | `Action<ValidatorEventArgs>`  | null         | Validation handler used to validate selected value.                                                   |


### PR DESCRIPTION
resolves #1350 AutoComplete validation works off text rather than value

Usage:

```cshtml
<Autocomplete TItem="MySelectModel"
                TValue="string"
                Data="@myDdlData"
                TextField="@((item)=>item.MyTextField)"
                ValueField="@((item)=>item.MyTextField)"
                SelectedValue="@selectedSearchValue"
                SelectedValueChanged="@MySearchHandler"
                Placeholder="Search..." Filter="AutocompleteFilter.StartsWith"
                Validator="IsValidValue">
</Autocomplete>
@code{
    void IsValidValue( ValidatorEventArgs e )
    {
        Console.WriteLine( e.Value );

        e.Status = !string.IsNullOrEmpty( e.Value?.ToString() ) && myDdlData.Any( x => x.MyTextField == e.Value.ToString() )
            ? ValidationStatus.Success
            : ValidationStatus.Error;

        if ( e.Status == ValidationStatus.Error )
        {
            e.ErrorText = "ERROR";
        }
        else
        {
            e.ErrorText = "OK";
        }
    }
}
```