### PR TITLE
RichTextEdit - Catch exception when try to destroy editor in Server side blazor after user closes window.

### DIFF
--- a/Source/Extensions/Blazorise.RichTextEdit/RichTextEditJsInterop.cs
+++ b/Source/Extensions/Blazorise.RichTextEdit/RichTextEditJsInterop.cs
@@ -62,7 +62,15 @@ namespace Blazorise.RichTextEdit
 
             return Disposable.Create( () =>
             {
-                DestroyEditor( richTextEdit.EditorRef );
+                try
+                {
+                    DestroyEditor( richTextEdit.EditorRef );
+                }
+                catch ( TaskCanceledException )
+                {
+                    //Connection closed
+                }
+
                 dotNetRef.Dispose();
             } );
         }


### PR DESCRIPTION
RichTextEdit in webassembly works great but in Blazor server there is issue. When user changes page RichTextEditor is properly disposed. But when user closes browser window, blazor cannot properly dispose RichTextEditor because connection is already closed.

After some time (probably some circuit keep timeout) i found in logs this
```
fail: Microsoft.AspNetCore.Components.Server.Circuits.CircuitHost[111]
      Unhandled exception in circuit '1pW1Gcc8G7g3RlKpoC4z5_gD7_o04wJWDLebHsxvtnQ'.
      System.Threading.Tasks.TaskCanceledException: A task was canceled.
         at Microsoft.JSInterop.JSRuntime.InvokeAsync[TValue](Int64 targetInstanceId, String identifier, Object[] args)
         at Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync(IJSRuntime jsRuntime, String identifier, Object[] args)
         at Blazorise.RichTextEdit.RichTextEditJsInterop.DestroyEditor(ElementReference editorRef)
         at Microsoft.AspNetCore.Components.Rendering.RendererSynchronizationContext.ExecuteSynchronously(TaskCompletionSource`1 completion, SendOrPostCallback d, Object state)
         at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
      --- End of stack trace from previous location ---
         at Microsoft.AspNetCore.Components.Rendering.RendererSynchronizationContext.ExecuteBackground(WorkItem item)
```
The error in log is one issue, I can live with it, but it also causes memory leeks, because dotnet reference on blazor side is not disposed due to this exception.
So I added try - catch for this. I don't know if there is better way to handle disconnect.