### PR TITLE
RichTextEdit - Catch exception when try to destroy editor in Server side blazor after user closes window.

### DIFF
--- a/Source/Extensions/Blazorise.RichTextEdit/RichTextEditJsInterop.cs
+++ b/Source/Extensions/Blazorise.RichTextEdit/RichTextEditJsInterop.cs
@@ -64,7 +64,15 @@ namespace Blazorise.RichTextEdit
 
             return Disposable.Create( () =>
             {
-                DestroyEditor( richTextEdit.EditorRef );
+                try
+                {
+                    DestroyEditor( richTextEdit.EditorRef );
+                }
+                catch ( TaskCanceledException )
+                {
+                    //Connection closed
+                }
+
                 dotNetRef.Dispose();
             } );
         }


### PR DESCRIPTION
#1867 