### PR TITLE
Datagrid: Introduced async / await on missing events. Introduced a Cancellation Token to issue a cancellation on page changed / page size changed

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor.cs
+++ b/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor.cs
@@ -179,7 +179,7 @@ namespace Blazorise.Demo.Pages.Tests
 
         async Task OnReadData( DataGridReadDataEventArgs<Employee> e )
         {
-            await Task.Delay( random.Next( 2500 ) );
+            await Task.Delay( random.Next( 800 ) );
 
             if ( !e.CancellationToken.IsCancellationRequested )
             {

--- a/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor.cs
+++ b/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor.cs
@@ -175,16 +175,21 @@ namespace Blazorise.Demo.Pages.Tests
                 || model.EMail?.Contains( customFilterValue, StringComparison.OrdinalIgnoreCase ) == true;
         }
 
-        Task OnReadData( DataGridReadDataEventArgs<Employee> e )
+        async Task OnReadData( DataGridReadDataEventArgs<Employee> e )
         {
-            // this can be call to anything, in this case we're calling a fictional api
-            var response = dataModels.Skip( ( e.Page - 1 ) * e.PageSize ).Take( e.PageSize ).ToList();
+            Random random = new Random();
+            await Task.Delay( random.Next( 2500 ) );
+            if( !e.CancellationToken.IsCancellationRequested )
+            { 
+                // this can be call to anything, in this case we're calling a fictional api
+                var response = dataModels.Skip( ( e.Page - 1 ) * e.PageSize ).Take( e.PageSize ).ToList();
 
-            employeeList = new List<Employee>( response ); // an actual data for the current page
-            totalEmployees = dataModels.Count; // this is used to tell datagrid how many items are available so that pagination will work
-
-            // always call StateHasChanged!
-            return InvokeAsync( StateHasChanged );
+                employeeList = new List<Employee>( response ); // an actual data for the current page
+                totalEmployees = dataModels.Count; // this is used to tell datagrid how many items are available so that pagination will work
+            
+                // always call StateHasChanged!
+                await InvokeAsync( StateHasChanged );
+            }
         }
 
         #endregion

--- a/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor.cs
+++ b/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor.cs
@@ -58,6 +58,8 @@ namespace Blazorise.Demo.Pages.Tests
         List<Employee> employeeList;
         int totalEmployees;
 
+        Random random = new Random();
+
         // generated with https://mockaroo.com/
         List<Employee> dataModels = new List<Employee>{
             new Employee {Id = 1,FirstName = "Caro",LastName = "Nizard",EMail = "cnizard0@hc360.com",City = "Faīẕābād",Zip = null,Salary = 51724.19m, DateOfBirth = new DateTime(1983,5,8),
@@ -177,16 +179,16 @@ namespace Blazorise.Demo.Pages.Tests
 
         async Task OnReadData( DataGridReadDataEventArgs<Employee> e )
         {
-            Random random = new Random();
             await Task.Delay( random.Next( 2500 ) );
-            if( !e.CancellationToken.IsCancellationRequested )
-            { 
+
+            if ( !e.CancellationToken.IsCancellationRequested )
+            {
                 // this can be call to anything, in this case we're calling a fictional api
                 var response = dataModels.Skip( ( e.Page - 1 ) * e.PageSize ).Take( e.PageSize ).ToList();
 
                 employeeList = new List<Employee>( response ); // an actual data for the current page
                 totalEmployees = dataModels.Count; // this is used to tell datagrid how many items are available so that pagination will work
-            
+
                 // always call StateHasChanged!
                 await InvokeAsync( StateHasChanged );
             }

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -169,7 +169,7 @@ namespace Blazorise.DataGrid
                     {
                         await InvokeAsync( StateHasChanged );
                     }
-                    
+
                 } );
 
                 paginationContext.SubscribeOnPageChanged( async currentPage =>
@@ -453,7 +453,7 @@ namespace Blazorise.DataGrid
 
             if ( ManualReadMode )
             {
-                return InvokeAsync( () => HandleReadData ( CancellationToken.None ) );
+                return InvokeAsync( () => HandleReadData( CancellationToken.None ) );
             }
             else
             {

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -192,7 +192,11 @@ namespace Blazorise.DataGrid
                 } );
 
                 if ( ManualReadMode )
+                {
                     await HandleReadData( CancellationToken.None );
+
+                    return;
+                }
 
                 // after all the columns have being "hooked" we need to resfresh the grid
                 await InvokeAsync( StateHasChanged );

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Blazorise.DataGrid.Utils;
 using Blazorise.Extensions;
@@ -147,50 +148,57 @@ namespace Blazorise.DataGrid
             Aggregates.Add( aggregate );
         }
 
-        protected override Task OnAfterRenderAsync( bool firstRender )
+        protected override async Task OnAfterRenderAsync( bool firstRender )
         {
             if ( firstRender )
             {
-                paginationContext.SubscribeOnPageSizeChanged( pageSize =>
+                paginationContext.SubscribeOnPageSizeChanged( async pageSize =>
                 {
-                    InvokeAsync( () => PageSizeChanged.InvokeAsync( pageSize ) );
+                    paginationContext.CancellationTokenSource?.Cancel();
+                    paginationContext.CancellationTokenSource = new CancellationTokenSource();
+
+                    await InvokeAsync( () => PageSizeChanged.InvokeAsync( pageSize ) );
 
                     // When using manual mode, a user is in control when StateHasChanged will be called
                     // so we just need to call HandleReadData.
                     if ( ManualReadMode )
                     {
-                        InvokeAsync( HandleReadData );
+                        await InvokeAsync( () => HandleReadData( paginationContext.CancellationTokenSource.Token ) );
                     }
                     else
                     {
-                        InvokeAsync( StateHasChanged );
+                        await InvokeAsync( StateHasChanged );
                     }
+                    
                 } );
 
-                paginationContext.SubscribeOnPageChanged( currentPage =>
+                paginationContext.SubscribeOnPageChanged( async currentPage =>
                 {
-                    InvokeAsync( () => PageChanged.InvokeAsync( new DataGridPageChangedEventArgs( currentPage, PageSize ) ) );
+                    paginationContext.CancellationTokenSource?.Cancel();
+                    paginationContext.CancellationTokenSource = new CancellationTokenSource();
+
+                    await InvokeAsync( () => PageChanged.InvokeAsync( new DataGridPageChangedEventArgs( currentPage, PageSize ) ) );
 
                     // When using manual mode, a user is in control when StateHasChanged will be called
                     // so we just need to call HandleReadData.
                     if ( ManualReadMode )
                     {
-                        InvokeAsync( HandleReadData );
+                        await InvokeAsync( () => HandleReadData( paginationContext.CancellationTokenSource.Token ) );
                     }
                     else
                     {
-                        InvokeAsync( StateHasChanged );
+                        await InvokeAsync( StateHasChanged );
                     }
                 } );
 
                 if ( ManualReadMode )
-                    return HandleReadData();
+                    await HandleReadData( CancellationToken.None );
 
                 // after all the columns have being "hooked" we need to resfresh the grid
-                InvokeAsync( StateHasChanged );
+                await InvokeAsync( StateHasChanged );
             }
 
-            return base.OnAfterRenderAsync( firstRender );
+            await base.OnAfterRenderAsync( firstRender );
         }
 
         #endregion
@@ -323,7 +331,7 @@ namespace Blazorise.DataGrid
                     // If a new item is added, the data should be refreshed
                     // to account for paging, sorting, and filtering
                     if ( ManualReadMode )
-                        await HandleReadData();
+                        await HandleReadData( CancellationToken.None );
                 }
                 else
                     await RowUpdated.InvokeAsync( new SavedRowItem<TItem, Dictionary<string, object>>( editItem, editedCellValues ) );
@@ -343,7 +351,7 @@ namespace Blazorise.DataGrid
                 PopupVisible = false;
         }
 
-        protected Task OnMultiSelectCommand( MultiSelectEventArgs<TItem> eventArgs )
+        protected async Task OnMultiSelectCommand( MultiSelectEventArgs<TItem> eventArgs )
         {
             SelectedAllRows = false;
             UnSelectAllRows = false;
@@ -364,11 +372,11 @@ namespace Blazorise.DataGrid
 
                 if ( SelectedRow.IsEqual( eventArgs.Item ) )
                 {
-                    SelectedRowChanged.InvokeAsync( default( TItem ) );
+                    await SelectedRowChanged.InvokeAsync( default( TItem ) );
                 }
             }
 
-            return SelectedRowsChanged.InvokeAsync( SelectedRows );
+            await SelectedRowsChanged.InvokeAsync( SelectedRows );
         }
 
         protected async Task OnMultiSelectAll( bool selectAll )
@@ -445,7 +453,7 @@ namespace Blazorise.DataGrid
 
             if ( ManualReadMode )
             {
-                return InvokeAsync( HandleReadData );
+                return InvokeAsync( () => HandleReadData ( CancellationToken.None ) );
             }
             else
             {
@@ -453,13 +461,13 @@ namespace Blazorise.DataGrid
             }
         }
 
-        protected async Task HandleReadData()
+        protected async Task HandleReadData( CancellationToken cancellationToken )
         {
             try
             {
                 IsLoading = true;
-
-                await ReadData.InvokeAsync( new DataGridReadDataEventArgs<TItem>( CurrentPage, PageSize, Columns ) );
+                if ( !cancellationToken.IsCancellationRequested )
+                    await ReadData.InvokeAsync( new DataGridReadDataEventArgs<TItem>( CurrentPage, PageSize, Columns, cancellationToken ) );
             }
             finally
             {
@@ -500,7 +508,7 @@ namespace Blazorise.DataGrid
                 dirtyFilter = dirtyView = true;
 
                 if ( ManualReadMode )
-                    return HandleReadData();
+                    return HandleReadData( CancellationToken.None );
             }
 
             return Task.CompletedTask;
@@ -512,7 +520,7 @@ namespace Blazorise.DataGrid
             dirtyFilter = dirtyView = true;
 
             if ( ManualReadMode )
-                return HandleReadData();
+                return HandleReadData( CancellationToken.None );
 
             return Task.CompletedTask;
         }
@@ -527,7 +535,7 @@ namespace Blazorise.DataGrid
             dirtyFilter = dirtyView = true;
 
             if ( ManualReadMode )
-                return HandleReadData();
+                return HandleReadData( CancellationToken.None );
 
             return Task.CompletedTask;
         }

--- a/Source/Extensions/Blazorise.DataGrid/EventArguments.cs
+++ b/Source/Extensions/Blazorise.DataGrid/EventArguments.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 #endregion
 
@@ -122,11 +123,12 @@ namespace Blazorise.DataGrid
         /// <param name="page">Page number at the moment of initialization.</param>
         /// <param name="pageSize">Maximum number of items per page.</param>
         /// <param name="columns">List of all the columns in the grid.</param>
-        public DataGridReadDataEventArgs( int page, int pageSize, IEnumerable<DataGridColumn<TItem>> columns )
+        public DataGridReadDataEventArgs( int page, int pageSize, IEnumerable<DataGridColumn<TItem>> columns, CancellationToken cancellationToken )
         {
             Page = page;
             PageSize = pageSize;
             Columns = columns?.Select( x => new DataGridColumnInfo( x.Field, x.Filter?.SearchValue, x.CurrentDirection, x.ColumnType ) );
+            CancellationToken = cancellationToken;
         }
 
         /// <summary>
@@ -143,6 +145,11 @@ namespace Blazorise.DataGrid
         /// Gets the list of columns.
         /// </summary>
         public IEnumerable<DataGridColumnInfo> Columns { get; }
+
+        /// <summary>
+        /// Gets the CancellationToken
+        /// </summary>
+        public CancellationToken CancellationToken { get; set; }
     }
 
     /// <summary>

--- a/Source/Extensions/Blazorise.DataGrid/PaginationContext.cs
+++ b/Source/Extensions/Blazorise.DataGrid/PaginationContext.cs
@@ -49,7 +49,7 @@ namespace Blazorise.DataGrid
         #endregion
 
         #region Methods
-                
+
         public void SubscribeOnPageChanged( CurrentPageChangedEventHandler listener )
         {
             CurrentPageChanged += listener;

--- a/Source/Extensions/Blazorise.DataGrid/PaginationContext.cs
+++ b/Source/Extensions/Blazorise.DataGrid/PaginationContext.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 #endregion
 
@@ -48,7 +49,7 @@ namespace Blazorise.DataGrid
         #endregion
 
         #region Methods
-
+                
         public void SubscribeOnPageChanged( CurrentPageChangedEventHandler listener )
         {
             CurrentPageChanged += listener;
@@ -124,6 +125,12 @@ namespace Blazorise.DataGrid
         #endregion
 
         #region Properties
+
+        /// <summary>
+        /// Gets the CancellationTokenSource which could be used to issue a cancellation.
+        /// </summary>
+        public CancellationTokenSource CancellationTokenSource { get; set; }
+
         /// <summary>
         /// Gets or sets the current page
         /// </summary>


### PR DESCRIPTION
Hello @stsrki 
Here's the changes I have suggested. Including the idea of a Cancellation token to be able to issue cancellations.

You can test it on the DataGrid Demo Page it now has a random delay on ReadData (when Large Data is selected). If you switch between pages or page sizes, it should always only display the latest operation whereas before, it would update the UI with all the queued operations.

Just let me know if you agree with this idea or not.