### PR TITLE
Datagrid multi selection fixes

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -32,7 +32,7 @@
                             @if ( MultiSelect )
                             {
                                 <TableHeaderCell Class="@column.HeaderCellClass" Style="@column.BuildHeaderCellStyle()" TextAlignment="@column.HeaderTextAlignment">
-                                    <_DataGridMultiSelectAll TItem="TItem" MultiSelectAll="@OnMultiSelectAll" IsIndeterminate="@IsMultiSelectAllIndeterminate"></_DataGridMultiSelectAll>
+                                    <_DataGridMultiSelectAll TItem="TItem" MultiSelectAll="@OnMultiSelectAll" IsIndeterminate="@IsMultiSelectAllIndeterminate()"></_DataGridMultiSelectAll>
                                 </TableHeaderCell>
                             }
                         }

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -32,7 +32,7 @@
                             @if ( MultiSelect )
                             {
                                 <TableHeaderCell Class="@column.HeaderCellClass" Style="@column.BuildHeaderCellStyle()" TextAlignment="@column.HeaderTextAlignment">
-                                    <_DataGridMultiSelectAll TItem="TItem" MultiSelectAll="@OnMultiSelectAll" IsIndeterminate="@IsMultiSelectAllIndeterminate()"></_DataGridMultiSelectAll>
+                                    <_DataGridMultiSelectAll TItem="TItem" MultiSelectAll="@OnMultiSelectAll" IsIndeterminate="@IsMultiSelectAllIndeterminate"></_DataGridMultiSelectAll>
                                 </TableHeaderCell>
                             }
                         }

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -727,21 +727,6 @@ namespace Blazorise.DataGrid
 
         #endregion
 
-        /// <summary>
-        /// Checks if the MultiSelectAll is indeterminate, meaning that only some of the current view rows are selected.
-        /// </summary>
-        private bool IsMultiSelectAllIndeterminate()
-        {
-            var isIndeterminate = false;
-            var hasSelectedRows = SelectedRows?.Any() ?? false;
-            if ( hasSelectedRows )
-            {
-                var unselectedRows = viewData.Except( SelectedRows ).Count();
-                isIndeterminate = MultiSelect && hasSelectedRows && ( unselectedRows > 0 ) && ( unselectedRows < viewData.Count() );
-            }
-            return isIndeterminate;
-        }
-
         #endregion
 
         #region Properties
@@ -913,6 +898,26 @@ namespace Blazorise.DataGrid
         /// Gets the reference to the associated multiselect column.
         /// </summary>
         public DataGridMultiSelectColumn<TItem> MultiSelectColumn { get; private set; }
+
+        /// <summary>
+        /// Checks if the MultiSelectAll is indeterminate, meaning that only some of the current view rows are selected.
+        /// </summary>
+        private bool IsMultiSelectAllIndeterminate
+        {
+            get
+            {
+                var hasSelectedRows = SelectedRows?.Any() ?? false;
+
+                if ( hasSelectedRows )
+                {
+                    var unselectedRows = viewData.Except( SelectedRows ).Count();
+
+                    return MultiSelect && hasSelectedRows && unselectedRows > 0 && unselectedRows < viewData.Count();
+                }
+
+                return false;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the datagrid data-source.

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -727,6 +727,21 @@ namespace Blazorise.DataGrid
 
         #endregion
 
+        /// <summary>
+        /// Checks if the MultiSelectAll is indeterminate, meaning that only some of the current view rows are selected.
+        /// </summary>
+        private bool IsMultiSelectAllIndeterminate()
+        {
+            var isIndeterminate = false;
+            var hasSelectedRows = SelectedRows?.Any() ?? false;
+            if ( hasSelectedRows )
+            {
+                var unselectedRows = viewData.Except( SelectedRows ).Count();
+                isIndeterminate = MultiSelect && hasSelectedRows && ( unselectedRows > 0 ) && ( unselectedRows < viewData.Count() );
+            }
+            return isIndeterminate;
+        }
+
         #endregion
 
         #region Properties
@@ -868,12 +883,6 @@ namespace Blazorise.DataGrid
             => ( SelectionMode == DataGridSelectionMode.Multiple );
 
         /// <summary>
-        /// Checks if the MultiSelectAll is indeterminate, meaning that only some of the current view rows are selected.
-        /// </summary>
-        private bool IsMultiSelectAllIndeterminate
-            => ( MultiSelect && ( SelectedRows?.Any() ?? false ) && !( viewData.Except( SelectedRows ).Count() == 0 ) );
-
-        /// <summary>
         /// Gets template for title of popup modal.
         /// </summary>
         [Parameter]
@@ -964,7 +973,7 @@ namespace Blazorise.DataGrid
         /// <summary>
         /// Gets the data to show on grid based on the filter and current page.
         /// </summary>
-        protected IEnumerable<TItem> DisplayData
+        internal IEnumerable<TItem> DisplayData
         {
             get
             {

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridMultiSelectAll.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridMultiSelectAll.razor.cs
@@ -20,15 +20,18 @@ namespace Blazorise.DataGrid
         protected override Task OnParametersSetAsync()
         {
             var hasSelectedRows = ParentDataGrid.SelectedRows?.Any() ?? false;
+
             if ( hasSelectedRows )
-            { 
+            {
                 var unselectedRows = ParentDataGrid.DisplayData.Except( ParentDataGrid.SelectedRows ).Any();
-                if ( ( hasSelectedRows ) && !unselectedRows )
+
+                if ( hasSelectedRows && !unselectedRows )
                     IsChecked = true;
 
                 if ( !hasSelectedRows || unselectedRows )
                     IsChecked = false;
             }
+
             return base.OnParametersSetAsync();
         }
 

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridMultiSelectAll.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridMultiSelectAll.razor.cs
@@ -19,12 +19,16 @@ namespace Blazorise.DataGrid
 
         protected override Task OnParametersSetAsync()
         {
-            if ( ParentDataGrid.PageSize == ParentDataGrid.SelectedRows?.Count )
-                IsChecked = true;
+            var hasSelectedRows = ParentDataGrid.SelectedRows?.Any() ?? false;
+            if ( hasSelectedRows )
+            { 
+                var unselectedRows = ParentDataGrid.DisplayData.Except( ParentDataGrid.SelectedRows ).Any();
+                if ( ( hasSelectedRows ) && !unselectedRows )
+                    IsChecked = true;
 
-            if ( ParentDataGrid.SelectedRows?.Count == 0 )
-                IsChecked = false;
-
+                if ( !hasSelectedRows || unselectedRows )
+                    IsChecked = false;
+            }
             return base.OnParametersSetAsync();
         }
 


### PR DESCRIPTION
You're probably getting tired of my PRs right about now... xD

Ok so the indeterminate flag was wrong when changing to an empty page just like you had tested it.
When fixing that, also the check all wasn't correctly updating with the currently DisplayData that was selected when switching back and forth between already visited pages.

Also made the logic a bit clearer by removing the expression body in favor of a simple method.

DisplayData was changed from Protected to Internal as I needed to access this information, that should be okay, but just tell me otherwise.