### PR TITLE
Optimized Validation to always use new validation value

### DIFF
--- a/Source/Blazorise/Components/Validation/Handlers/DataAnnotationValidationHandler.cs
+++ b/Source/Blazorise/Components/Validation/Handlers/DataAnnotationValidationHandler.cs
@@ -40,12 +40,7 @@ namespace Blazorise
                 ? messages[validation.FieldIdentifier]
                 : null;
 
-            // Sometime status will stay the same and error message will change
-            // eg. StringLength > empty string > Required
-            if ( validation.Status != matchStatus || ( validation.Messages?.ToArray()?.AreEqual( matchMessages?.ToArray() ) == false ) )
-            {
-                validation.NotifyValidationStatusChanged( matchStatus, matchMessages );
-            }
+            validation.NotifyValidationStatusChanged( matchStatus, matchMessages );
         }
 
         /// <summary>

--- a/Source/Blazorise/Components/Validation/Handlers/PatternValidationHandler.cs
+++ b/Source/Blazorise/Components/Validation/Handlers/PatternValidationHandler.cs
@@ -17,10 +17,7 @@ namespace Blazorise
                 ? ValidationStatus.Success
                 : ValidationStatus.Error;
 
-            if ( validation.Status != matchStatus )
-            {
-                validation.NotifyValidationStatusChanged( matchStatus );
-            }
+            validation.NotifyValidationStatusChanged( matchStatus );
         }
     }
 }

--- a/Source/Blazorise/Components/Validation/Handlers/ValidatorValidationHandler.cs
+++ b/Source/Blazorise/Components/Validation/Handlers/ValidatorValidationHandler.cs
@@ -23,10 +23,7 @@ namespace Blazorise
                 ? new string[] { validatorEventArgs.ErrorText }
                 : null;
 
-            if ( validation.Status != validatorEventArgs.Status || ( validation.Messages?.ToArray()?.AreEqual( matchMessages ) == false ) )
-            {
-                validation.NotifyValidationStatusChanged( validatorEventArgs.Status, matchMessages );
-            }
+            validation.NotifyValidationStatusChanged( validatorEventArgs.Status, matchMessages );
         }
     }
 }

--- a/Source/Blazorise/Components/Validation/Validation.razor.cs
+++ b/Source/Blazorise/Components/Validation/Validation.razor.cs
@@ -1,6 +1,7 @@
 ﻿#region Using directives
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -24,11 +25,6 @@ namespace Blazorise
         private IValidationInput inputComponent;
 
         /// <summary>
-        /// Holds the last input value.
-        /// </summary>
-        private object lastValidationValue;
-
-        /// <summary>
         /// Pattern that is being applied for the validation.
         /// </summary>
         private string patternString;
@@ -43,7 +39,9 @@ namespace Blazorise
         /// </summary>
         private bool hasPattern;
 
-        // Flag that indicates validation has already being initialized.
+        /// <summary>
+        /// Flag that indicates validation has already being initialized.
+        /// </summary>
         private bool initialized;
 
         /// <summary>
@@ -97,9 +95,6 @@ namespace Blazorise
         internal void InitializeInput( IValidationInput inputComponent )
         {
             this.inputComponent = inputComponent;
-
-            // save the input value
-            lastValidationValue = inputComponent.ValidationValue;
 
             if ( Mode == ValidationMode.Auto && ValidateOnLoad )
                 Validate( inputComponent.ValidationValue );
@@ -165,21 +160,14 @@ namespace Blazorise
                 ? newExpressionValue
                 : inputComponent.ValidationValue;
 
-            var valueChanged = newValidationValue is IEnumerable<T> newArrayValue && lastValidationValue is IEnumerable<T> lastArrayValue
-                ? !lastArrayValue.AreEqual( newArrayValue )
-                : !lastValidationValue.IsEqual( newValidationValue );
-
-            if ( valueChanged )
+            if ( EditContext != null && hasFieldIdentifier )
             {
-                lastValidationValue = newValidationValue;
+                EditContext.NotifyFieldChanged( fieldIdentifier );
+            }
 
-                if ( EditContext != null && hasFieldIdentifier )
-                {
-                    EditContext.NotifyFieldChanged( fieldIdentifier );
-                }
-
-                if ( Mode == ValidationMode.Auto )
-                    Validate( newValidationValue );
+            if ( Mode == ValidationMode.Auto )
+            {
+                Validate( newValidationValue );
             }
         }
 
@@ -265,13 +253,17 @@ namespace Blazorise
 
         public void NotifyValidationStatusChanged( ValidationStatus status, IEnumerable<string> messages = null )
         {
-            Status = status;
-            Messages = messages;
+            // raise events only if status or message is changed to prevent unnecessary re-renders
+            if ( Status != status || ( Messages?.AreEqual( messages ) == false ) )
+            {
+                Status = status;
+                Messages = messages;
 
-            ValidationStatusChanged?.Invoke( this, new ValidationStatusChangedEventArgs( status, messages ) );
-            StatusChanged.InvokeAsync( status );
+                ValidationStatusChanged?.Invoke( this, new ValidationStatusChangedEventArgs( status, messages ) );
+                StatusChanged.InvokeAsync( status );
 
-            ParentValidations?.NotifyValidationStatusChanged( this );
+                ParentValidations?.NotifyValidationStatusChanged( this );
+            }
         }
 
         #endregion


### PR DESCRIPTION
Validation no longer remembers the last received value. This was problematic because in some cases the validation would not be raised even though the input real value has changed.