### PR TITLE
Datagrid: Is pager visible when button row is on and grid is Empty with an EmptyTemplate set

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
@@ -198,6 +198,7 @@
                           Responsive="true"
                           ValidationsSummaryLabel="Following error occurs..."
                           CustomFilter="@OnCustomFilter">
+                    <EmptyTemplate>No records...</EmptyTemplate>
                     <DataGridAggregates>
                         <DataGridAggregate TItem="Employee" Field="@nameof( Employee.EMail )" Aggregate="DataGridAggregateType.Count">
                             <DisplayTemplate>

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -818,7 +818,7 @@ namespace Blazorise.DataGrid
         /// <summary>
         /// Returns true if ShowPager is true and grid is not empty or loading.
         /// </summary>
-        protected bool IsPagerVisible => !IsEmptyTemplateVisible && !IsLoadingTemplateVisible && ShowPager;
+        protected bool IsPagerVisible => ShowPager && !IsLoadingTemplateVisible && ( ( IsButtonRowVisible && ButtonRowTemplate != null ) ||  !IsEmptyTemplateVisible );
 
         /// <summary>
         /// Returns true if current state is for new item and editing fields are shown on datagrid.

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -818,7 +818,7 @@ namespace Blazorise.DataGrid
         /// <summary>
         /// Returns true if ShowPager is true and grid is not empty or loading.
         /// </summary>
-        protected bool IsPagerVisible => ShowPager && !IsLoadingTemplateVisible && ( ( IsButtonRowVisible && ButtonRowTemplate != null ) ||  !IsEmptyTemplateVisible );
+        protected bool IsPagerVisible => ShowPager && !IsLoadingTemplateVisible && ( ( IsButtonRowVisible && ButtonRowTemplate != null ) || !IsEmptyTemplateVisible );
 
         /// <summary>
         /// Returns true if current state is for new item and editing fields are shown on datagrid.


### PR DESCRIPTION
Closes #1913 

I was thinking if it made sense to show when loading, maybe the user could have a button to cancel the ongoing loading... but I left that as it was for now.