### PR TITLE
Datagrid Resize : Ignore clicks from resizer triggering sort or other click events.

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -1022,14 +1022,8 @@ namespace Blazorise.DataGrid
 
                 resizable = value;
 
-                if ( resizable )
-                {
-                    ExecuteAfterRender( () => InitResizable().AsTask() );
-                }
-                else
-                {
+                if ( !resizable )
                     ExecuteAfterRender( () => DestroyResizable().AsTask() );
-                }
             }
         }
 

--- a/Source/Extensions/Blazorise.DataGrid/wwwroot/blazorise.datagrid.css
+++ b/Source/Extensions/Blazorise.DataGrid/wwwroot/blazorise.datagrid.css
@@ -13,5 +13,10 @@
 }
 
     .b-datagrid-resizer:hover, .b-datagrid-resizing {
+        cursor: col-resize !important;
         border-right: 2px solid var(--b-theme-primary, blue);
     }
+
+.b-datagrid-resizing {
+    cursor: col-resize !important;
+}

--- a/Source/Extensions/Blazorise.DataGrid/wwwroot/blazorise.datagrid.js
+++ b/Source/Extensions/Blazorise.DataGrid/wwwroot/blazorise.datagrid.js
@@ -36,8 +36,7 @@
                 // Set the height
                 resizer.style.height = `${actualHeight}px`;
 
-                resizer.addEventListener("click", function (e)
-                {
+                resizer.addEventListener("click", function (e) {
                     e.preventDefault();
                     e.stopPropagation();
                 });

--- a/Source/Extensions/Blazorise.DataGrid/wwwroot/blazorise.datagrid.js
+++ b/Source/Extensions/Blazorise.DataGrid/wwwroot/blazorise.datagrid.js
@@ -1,4 +1,5 @@
-﻿window.blazoriseDataGrid = {
+﻿var r;
+window.blazoriseDataGrid = {
 
     initResizable: function (table, mode) {
         const resizerClass = "b-datagrid-resizer";
@@ -45,7 +46,7 @@
 
                 let mouseDownDate;
                 let mouseUpDate;
-                col.addEventListener('click', function (e) {
+                r = function (e) {
                     let resized = (mouseDownDate != null && mouseUpDate != null);
                     if (resized) {
                         let currentDate = new Date();
@@ -61,12 +62,14 @@
                         let clickFromResizeJustNow = elapsedFromMouseUp < 100;
 
                         if (resized && clickFromResize && clickFromResizeJustNow) {
+                            e.preventDefault();
                             e.stopPropagation();
                         }
                         mouseDownDate = null;
                         mouseUpDate = null;
                     }
-                });
+                };
+                col.addEventListener('click', r );
                 col.appendChild(resizer);
 
                 // Track the current position of mouse
@@ -75,6 +78,8 @@
 
                 const mouseDownHandler = function (e) {
                     mouseDownDate = new Date();
+
+                    cols.forEach(x => x.classList.add('b-datagrid-resizing'));
 
                     // Get the current mouse position
                     x = e.clientX;
@@ -104,6 +109,8 @@
                 const mouseUpHandler = function () {
                     mouseUpDate = new Date();
 
+                    cols.forEach(x => x.classList.remove('b-datagrid-resizing'));
+
                     resizer.classList.remove(resizingClass);
 
                     table.querySelectorAll(`.${resizerClass}`).forEach(x => x.style.height = `${calculateModeHeight()}px`);
@@ -121,7 +128,9 @@
             });
         }
     },
+    r: function (e) { },
     destroyResizable: function (table) {
         table.querySelectorAll('.b-datagrid-resizer').forEach(x => x.remove());
+        table.querySelectorAll('tr:first-child > th').forEach(x => x.removeEventListener('click',r));
     }
 }; 

--- a/Source/Extensions/Blazorise.DataGrid/wwwroot/blazorise.datagrid.js
+++ b/Source/Extensions/Blazorise.DataGrid/wwwroot/blazorise.datagrid.js
@@ -28,6 +28,8 @@
             let actualHeight = calculateModeHeight();
 
             const createResizableColumn = function (col) {
+                if (col.querySelector(`.${resizerClass}`) != null)
+                    return;
                 // Add a resizer element to the column
                 const resizer = document.createElement('div');
                 resizer.classList.add(resizerClass);

--- a/Source/Extensions/Blazorise.DataGrid/wwwroot/blazorise.datagrid.js
+++ b/Source/Extensions/Blazorise.DataGrid/wwwroot/blazorise.datagrid.js
@@ -5,7 +5,7 @@
         const resizerHeaderMode = 0;
 
         const cols = table.querySelectorAll('tr:first-child > th');
-        if (cols != null) {
+        if (cols !== null) {
 
             const calculateTableActualHeight = function () {
                 let height = 0;
@@ -13,7 +13,7 @@
 
                 tableRows.forEach(x => {
                     let firstCol = x.querySelector('th:first-child,td:first-child');
-                    if (firstCol != null) {
+                    if (firstCol !== null) {
                         height += firstCol.offsetHeight;
                     }
                 });
@@ -21,13 +21,13 @@
             };
 
             const calculateModeHeight = () => {
-                return mode == resizerHeaderMode ? table.querySelector('tr:first-child > th:first-child').offsetHeight : calculateTableActualHeight();
+                return mode === resizerHeaderMode ? table.querySelector('tr:first-child > th:first-child').offsetHeight : calculateTableActualHeight();
             };
 
             let actualHeight = calculateModeHeight();
 
             const createResizableColumn = function (col) {
-                if (col.querySelector(`.${resizerClass}`) != null)
+                if (col.querySelector(`.${resizerClass}`) !== null)
                     return;
                 // Add a resizer element to the column
                 const resizer = document.createElement('div');
@@ -45,7 +45,7 @@
                 let mouseUpDate;
 
                 col.addEventListener('click', function (e) {
-                    let resized = (mouseDownDate != null && mouseUpDate != null);
+                    let resized = (mouseDownDate !== null && mouseUpDate !== null);
                     if (resized) {
                         let currentDate = new Date();
 

--- a/Source/Extensions/Blazorise.DataGrid/wwwroot/blazorise.datagrid.js
+++ b/Source/Extensions/Blazorise.DataGrid/wwwroot/blazorise.datagrid.js
@@ -1,6 +1,4 @@
-﻿var r;
-window.blazoriseDataGrid = {
-
+﻿window.blazoriseDataGrid = {
     initResizable: function (table, mode) {
         const resizerClass = "b-datagrid-resizer";
         const resizingClass = "b-datagrid-resizing";
@@ -46,7 +44,8 @@ window.blazoriseDataGrid = {
 
                 let mouseDownDate;
                 let mouseUpDate;
-                r = function (e) {
+
+                col.addEventListener('click', function (e) {
                     let resized = (mouseDownDate != null && mouseUpDate != null);
                     if (resized) {
                         let currentDate = new Date();
@@ -68,8 +67,7 @@ window.blazoriseDataGrid = {
                         mouseDownDate = null;
                         mouseUpDate = null;
                     }
-                };
-                col.addEventListener('click', r );
+                });
                 col.appendChild(resizer);
 
                 // Track the current position of mouse
@@ -128,9 +126,7 @@ window.blazoriseDataGrid = {
             });
         }
     },
-    r: function (e) { },
     destroyResizable: function (table) {
         table.querySelectorAll('.b-datagrid-resizer').forEach(x => x.remove());
-        table.querySelectorAll('tr:first-child > th').forEach(x => x.removeEventListener('click',r));
     }
 }; 

--- a/Source/Extensions/Blazorise.DataGrid/wwwroot/blazorise.datagrid.js
+++ b/Source/Extensions/Blazorise.DataGrid/wwwroot/blazorise.datagrid.js
@@ -35,6 +35,36 @@
                 // Set the height
                 resizer.style.height = `${actualHeight}px`;
 
+                resizer.addEventListener("click", function (e)
+                {
+                    e.preventDefault();
+                    e.stopPropagation();
+                });
+
+                let mouseDownDate;
+                let mouseUpDate;
+                col.addEventListener('click', function (e) {
+                    let resized = (mouseDownDate != null && mouseUpDate != null);
+                    if (resized) {
+                        let currentDate = new Date();
+
+                        // Checks if mouse down was some ms ago, which means click from resizing
+                        let elapsedFromMouseDown = currentDate - mouseDownDate;
+                        let clickFromResize = elapsedFromMouseDown > 100;
+
+                        // Checks if mouse up was some ms ago, which either means: 
+                        // we clicked from resizing just now or 
+                        // did not click from resizing and should handle click normally.
+                        let elapsedFromMouseUp = currentDate - mouseUpDate;
+                        let clickFromResizeJustNow = elapsedFromMouseUp < 100;
+
+                        if (resized && clickFromResize && clickFromResizeJustNow) {
+                            e.stopPropagation();
+                        }
+                        mouseDownDate = null;
+                        mouseUpDate = null;
+                    }
+                });
                 col.appendChild(resizer);
 
                 // Track the current position of mouse
@@ -42,6 +72,8 @@
                 let w = 0;
 
                 const mouseDownHandler = function (e) {
+                    mouseDownDate = new Date();
+
                     // Get the current mouse position
                     x = e.clientX;
 
@@ -68,6 +100,8 @@
 
                 // When user releases the mouse, remove the existing event listeners
                 const mouseUpHandler = function () {
+                    mouseUpDate = new Date();
+
                     resizer.classList.remove(resizingClass);
 
                     table.querySelectorAll(`.${resizerClass}`).forEach(x => x.style.height = `${calculateModeHeight()}px`);


### PR DESCRIPTION
Closes #1928 

So here I was thinking the fix would be as easy as to preventPropagation on the resizable click... Oh damn, I was so wrong...
Well that did solve most of it, but resizing and leaving the mouse on top of the adjacent parent column, would still trigger the column mouseup event and corresponding click.

As soon as mouseup event is triggered there's no way to stop the click event. So I've had to try a few things to avoid triggering the mouseup event when resizing on top of the column, 
- I tried setting the pointer-Events to none, which actually worked, but then the mouse would loose the resize look... no good.
- There was also a way to wrap the column itself in a div and stop the click from propagating below, but that would be changing the table's HTML, which could eventually mess people's css or expected markup... so no good...
				
I ended up just tracking the dates of when the mousedown and mouseup from resizing were triggered and then do logic to cancel the click event, if I determined it came from the resizer.

I also noticed the init was running more then once, duplicating resizers unnecessarily, so I removed an interop and still added a check to the js.