### PR TITLE
DataGrid: MultiSelectAll: BugFix When only one row, not unchecking the multi select all checkbox

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/_DataGridMultiSelectAll.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridMultiSelectAll.razor.cs
@@ -32,6 +32,10 @@ namespace Blazorise.DataGrid
                 if ( !hasSelectedRows || unselectedRows )
                     IsChecked = false;
             }
+            else
+            {
+                IsChecked = false;
+            }
 
             return base.OnParametersSetAsync();
         }

--- a/Source/Extensions/Blazorise.DataGrid/_DataGridMultiSelectAll.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/_DataGridMultiSelectAll.razor.cs
@@ -19,23 +19,9 @@ namespace Blazorise.DataGrid
 
         protected override Task OnParametersSetAsync()
         {
-            var hasSelectedRows = ParentDataGrid.SelectedRows?.Any() ?? false;
-
-            if ( hasSelectedRows )
-            {
-                var hasData = ParentDataGrid.DisplayData.Any();
-                var unselectedRows = ParentDataGrid.DisplayData.Except( ParentDataGrid.SelectedRows ).Any();
-
-                if ( hasSelectedRows && !unselectedRows && hasData )
-                    IsChecked = true;
-
-                if ( !hasSelectedRows || unselectedRows )
-                    IsChecked = false;
-            }
-            else
-            {
-                IsChecked = false;
-            }
+            IsChecked = ( ParentDataGrid.SelectedRows?.Any() ?? false )
+                && ParentDataGrid.DisplayData.Any()
+                && !ParentDataGrid.DisplayData.Except( ParentDataGrid.SelectedRows ).Any();
 
             return base.OnParametersSetAsync();
         }


### PR DESCRIPTION
Closes #1947 

I also noticed while testing, that clicking Delete triggers the RowClick, which means it will change SelectedRow / SelectedRows... This should only potentially be a problem with static data. But so far I haven't seen complaints about this which is strange. Not sure if we sould look at this in the future?

Personally, I just unselect SelectedRow myself when doing certain operations on the DataGrid. Since I use Grids that depend on the SelectedRow of other Grids.