### PR TITLE
Optimize the IdGenerator class.

### DIFF
--- a/Source/Blazorise/Utilities/IDGenerator.cs
+++ b/Source/Blazorise/Utilities/IDGenerator.cs
@@ -1,5 +1,6 @@
 ﻿#region Using directives
 using System;
+using System.Buffers;
 using System.Threading;
 #endregion
 
@@ -14,20 +15,22 @@ namespace Blazorise.Utilities
     {
         #region Members
 
-        private const string Encode32Chars = "0123456789ABCDEFGHIJKLMNOPQRSTUV";
+        private const int IdLength = 13;
 
         private static long LastId = DateTime.UtcNow.Ticks;
 
-        private static readonly ThreadLocal<char[]> CharBufferThreadLocal = new( () => new char[13] );
+        private static readonly SpanAction<char, long> GenerateImplDelegate = GenerateImpl;
 
         #endregion
 
         #region Methods
 
-        private static string GenerateImpl( long id )
+        private static void GenerateImpl( Span<char> buffer, long id )
         {
-            var buffer = CharBufferThreadLocal.Value;
 
+            var Encode32Chars = "0123456789ABCDEFGHIJKLMNOPQRSTUV";
+            // Accessing the last item in the beginning elides range checks for all the subsequent items.
+            buffer[12] = Encode32Chars[(int)id & 31];
             buffer[0] = Encode32Chars[(int)( id >> 60 ) & 31];
             buffer[1] = Encode32Chars[(int)( id >> 55 ) & 31];
             buffer[2] = Encode32Chars[(int)( id >> 50 ) & 31];
@@ -40,9 +43,7 @@ namespace Blazorise.Utilities
             buffer[9] = Encode32Chars[(int)( id >> 15 ) & 31];
             buffer[10] = Encode32Chars[(int)( id >> 10 ) & 31];
             buffer[11] = Encode32Chars[(int)( id >> 5 ) & 31];
-            buffer[12] = Encode32Chars[(int)id & 31];
 
-            return new string( buffer, 0, buffer.Length );
         }
 
         #endregion
@@ -52,7 +53,14 @@ namespace Blazorise.Utilities
         /// <summary>
         /// Returns a random ID. e.g: <c>0HLH7Q6V92BQE</c>
         /// </summary>
-        public string Generate => GenerateImpl( Interlocked.Increment( ref LastId ) );
+        public string Generate
+        {
+            get
+            {
+                var id = Interlocked.Increment( ref LastId );
+                return string.Create(IdLength, id, GenerateImplDelegate);
+            }
+        }
 
         #endregion
     }

--- a/Source/Blazorise/Utilities/IDGenerator.cs
+++ b/Source/Blazorise/Utilities/IDGenerator.cs
@@ -19,15 +19,12 @@ namespace Blazorise.Utilities
 
         private static long LastId = DateTime.UtcNow.Ticks;
 
-        private static readonly SpanAction<char, long> GenerateImplDelegate = GenerateImpl;
-
         #endregion
 
         #region Methods
 
         private static void GenerateImpl( Span<char> buffer, long id )
         {
-
             var Encode32Chars = "0123456789ABCDEFGHIJKLMNOPQRSTUV";
             // Accessing the last item in the beginning elides range checks for all the subsequent items.
             buffer[12] = Encode32Chars[(int)id & 31];
@@ -43,7 +40,6 @@ namespace Blazorise.Utilities
             buffer[9] = Encode32Chars[(int)( id >> 15 ) & 31];
             buffer[10] = Encode32Chars[(int)( id >> 10 ) & 31];
             buffer[11] = Encode32Chars[(int)( id >> 5 ) & 31];
-
         }
 
         #endregion
@@ -58,7 +54,7 @@ namespace Blazorise.Utilities
             get
             {
                 var id = Interlocked.Increment( ref LastId );
-                return string.Create(IdLength, id, GenerateImplDelegate);
+                return string.Create( IdLength, id, GenerateImpl );
             }
         }
 

--- a/docs/_docs/meta/releases.md
+++ b/docs/_docs/meta/releases.md
@@ -6,6 +6,12 @@ toc: true
 toc_label: "Version history"
 ---
 
+## 0.9.3
+
+### Changes
+
+For detail description of changes please look at [v0.9.3 release page]({{ "/news/release-notes/093/" | relative_url }})
+
 ## 0.9.2
 
 ### Changes


### PR DESCRIPTION
The use of `string.Create` reduces the overhead of copying character buffers around, and eliminates the need for thread-local storage.