### PR TITLE
Datagrid : Resizable : Fix js trying to access inexisting element when Datagrid has already been disposed.

### DIFF
--- a/Source/Extensions/Blazorise.DataGrid/wwwroot/blazorise.datagrid.js
+++ b/Source/Extensions/Blazorise.DataGrid/wwwroot/blazorise.datagrid.js
@@ -86,8 +86,6 @@
                 const mouseDownHandler = function (e) {
                     mouseDownDate = new Date();
 
-                    cols.forEach(x => x.classList.add('b-datagrid-resizing'));
-
                     // Get the current mouse position
                     x = e.clientX;
 
@@ -115,8 +113,6 @@
                 // When user releases the mouse, remove the existing event listeners
                 const mouseUpHandler = function () {
                     mouseUpDate = new Date();
-
-                    cols.forEach(x => x.classList.remove('b-datagrid-resizing'));
 
                     resizer.classList.remove(resizingClass);
 

--- a/Source/Extensions/Blazorise.DataGrid/wwwroot/blazorise.datagrid.js
+++ b/Source/Extensions/Blazorise.DataGrid/wwwroot/blazorise.datagrid.js
@@ -3,25 +3,35 @@
         const resizerClass = "b-datagrid-resizer";
         const resizingClass = "b-datagrid-resizing";
         const resizerHeaderMode = 0;
+        let cols = null;
 
-        const cols = table.querySelectorAll('tr:first-child > th');
+        if (table !== null) {
+            cols = table.querySelectorAll('tr:first-child > th');
+        }
+
         if (cols !== null) {
 
             const calculateTableActualHeight = function () {
                 let height = 0;
-                const tableRows = table.querySelectorAll('tr');
+                if (table !== null) {
+                    const tableRows = table.querySelectorAll('tr');
 
-                tableRows.forEach(x => {
-                    let firstCol = x.querySelector('th:first-child,td:first-child');
-                    if (firstCol !== null) {
-                        height += firstCol.offsetHeight;
-                    }
-                });
+                    tableRows.forEach(x => {
+                        let firstCol = x.querySelector('th:first-child,td:first-child');
+                        if (firstCol !== null) {
+                            height += firstCol.offsetHeight;
+                        }
+                    });
+                }
                 return height;
             };
 
             const calculateModeHeight = () => {
-                return mode === resizerHeaderMode ? table.querySelector('tr:first-child > th:first-child').offsetHeight : calculateTableActualHeight();
+                return mode === resizerHeaderMode
+                    ? table !== null
+                        ? table.querySelector('tr:first-child > th:first-child').offsetHeight
+                        : 0
+                    : calculateTableActualHeight();
             };
 
             let actualHeight = calculateModeHeight();
@@ -126,6 +136,8 @@
         }
     },
     destroyResizable: function (table) {
-        table.querySelectorAll('.b-datagrid-resizer').forEach(x => x.remove());
+        if (table !== null) {
+            table.querySelectorAll('.b-datagrid-resizer').forEach(x => x.remove());
+        }
     }
 }; 


### PR DESCRIPTION
Closes #2008 

this check seemed to be enough
```
if (table !== null) {
    cols = table.querySelectorAll('tr:first-child > th');
}
```
but I added whenever we're accessing the table, just in case.

Also removed 
`cols.forEach(x => x.classList.add('b-datagrid-resizing'));`
`cols.forEach(x => x.classList.remove('b-datagrid-resizing'));`
I have no idea why we had those in. Maybe commited by mistake.
Retested BS/Ant/Bulma/Material.

By the way have you noticed this on Ant? I don't really know the provider, but does not seem normal to me, for a dropdown to not show the selected value until clicked. Happens on other places on the demo with dropdowns.
![image](https://user-images.githubusercontent.com/22283161/110847094-67a44b80-82a4-11eb-9785-ead40075c7a2.png)
