### PR TITLE
Fix Sidebar missing collapse icons

### DIFF
--- a/Source/Extensions/Blazorise.Sidebar/SidebarLink.razor
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarLink.razor
@@ -1,4 +1,4 @@
 ﻿@inherits BaseComponent
-<Blazorise.Link Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@Attributes">
+<Blazorise.Link Class="@ClassNames" Style="@StyleNames" To="@To" Target="@Target" Title="@Title" Match="@Match" Clicked="@ClickHandler" Attributes="@LinkAttributes">
     @ChildContent
 </Blazorise.Link>

--- a/Source/Extensions/Blazorise.Sidebar/SidebarLink.razor.cs
+++ b/Source/Extensions/Blazorise.Sidebar/SidebarLink.razor.cs
@@ -1,4 +1,6 @@
 ﻿#region Using directives
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Blazorise.Utilities;
 using Microsoft.AspNetCore.Components;
@@ -57,6 +59,27 @@ namespace Blazorise.Sidebar
         protected string DataToggle => Collapsable ? "sidebar-collapse" : null;
 
         protected string AriaExpanded => Collapsable ? Visible.ToString().ToLowerInvariant() : null;
+
+        /// <summary>
+        /// Gets the combined list of link attributes and any receiving attribute.
+        /// </summary>
+        protected Dictionary<string, object> LinkAttributes
+        {
+            get
+            {
+                var linkAttributes = new Dictionary<string, object>()
+                {
+                    { "data-toggle", DataToggle },
+                    { "aria-expanded", AriaExpanded },
+                };
+
+                if ( Attributes != null )
+                    return linkAttributes.Concat( Attributes ).ToDictionary( x => x.Key, x => x.Value );
+
+                return linkAttributes;
+            }
+        }
+
 
         [Parameter]
         public bool Visible


### PR DESCRIPTION
fixes #2066 SideBarNavigation doesn't display drop down arrow with upgrade of Blazorise.Bootstrap and Blazorise.Icons.FontAwesome.