### PR TITLE
Adds CustomFilter function on the DataGridColumn

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
@@ -208,11 +208,11 @@
                                 @($"Total emails: {context.Value}")
                             </DisplayTemplate>
                         </DataGridAggregate>
-                        <DataGridAggregate TItem="Employee" Field="@nameof( Employee.Salary )"                                             
+                        <DataGridAggregate TItem="Employee" Field="@nameof( Employee.Salary )"
                                            AggregationFunction=@((values,col)=>values.Where(v=>v.IsActive).Sum(v=>v.Salary))
                                            DisplayFormatProvider="@System.Globalization.CultureInfo.GetCultureInfo("fr-FR")">
                         </DataGridAggregate>
-                        <DataGridAggregate TItem="Employee" Field="@nameof( Employee.IsActive )" 
+                        <DataGridAggregate TItem="Employee" Field="@nameof( Employee.IsActive )"
                                            AggregationFunction=@(DataGridAggregate<Employee>.TrueCount) />
                     </DataGridAggregates>
                     <DataGridColumns>
@@ -251,7 +251,7 @@
                         <DataGridColumn TextAlignment="TextAlignment.Center" TItem="Employee" Field="@nameof( Employee.Id )" Caption="#" Sortable="false" Width="60px" />
                         <DataGridColumn TItem="Employee" Field="@nameof( Employee.FirstName )" Caption="First Name" Validator="@CheckFirstName" Editable="true">
                             <FilterTemplate>
-                                <TextEdit Placeholder="Search name" Text="@context.SearchValue" TextChanged="@(v=> context.TriggerFilterChange(v))" />
+                                <TextEdit Placeholder="Search name" Text="@context.SearchValue?.ToString()" TextChanged="@(v=> context.TriggerFilterChange(v))" />
                             </FilterTemplate>
                         </DataGridColumn>
                         <DataGridColumn TItem="Employee" Field="@nameof( Employee.LastName )" Caption="Last Name" Editable="true" ValidationPattern="[A-Za-z]{3}" />
@@ -262,7 +262,7 @@
                             </CaptionTemplate>
                             <FilterTemplate>
                                 @{
-                                    var selectedValue = @context.SearchValue ?? "*";
+                                    var selectedValue = @context.SearchValue?.ToString() ?? "*";
                                     <Select TValue="string" SelectedValue="@selectedValue" SelectedValueChanged="@(e => context.TriggerFilterChange(e == "*" ? "" : e.ToString()))">
                                         <SelectItem Value="@("*")">All</SelectItem>
                                         @foreach ( var item in dataModels )
@@ -280,7 +280,18 @@
                         </DataGridColumn>
                         <DataGridDateColumn TItem="Employee" Field="@nameof( Employee.DateOfBirth )" DisplayFormat="{0:dd.MM.yyyy}" Caption="Date Of Birth" Editable="true" />
                         <DataGridNumericColumn TItem="Employee" Field="@nameof( Employee.Childrens )" Caption="Childrens" Editable="true" Filterable="false" />
-                        <DataGridSelectColumn TItem="Employee" Field="@nameof( Employee.Gender )" Caption="Gender" Editable="true">
+                        <DataGridSelectColumn CustomFilter="@CustomGenderFilter" TItem="Employee" Field="@nameof( Employee.Gender )" Caption="Gender" Editable="true">
+                            <FilterTemplate>
+                                <Select TValue="string" SelectedValue="@selectedGenderFilter" SelectedValueChanged="@(value => { selectedGenderFilter = value; context.TriggerFilterChange( selectedGenderFilter ); })">
+                                    <SelectItem TValue="string" Value="@("*")">All</SelectItem>
+                                    <SelectItem TValue="string" Value="@("M")">Male</SelectItem>
+                                    <SelectItem TValue="string" Value="@("F")">Female</SelectItem>
+                                    <SelectItem TValue="string" Value="@("D")">Diverse</SelectItem>
+                                </Select>
+                            </FilterTemplate>
+                            @code{
+                                
+                            }
                             <DisplayTemplate>
                                 @{
                                     var gender = ( context as Employee )?.Gender;

--- a/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor
@@ -280,7 +280,7 @@
                         </DataGridColumn>
                         <DataGridDateColumn TItem="Employee" Field="@nameof( Employee.DateOfBirth )" DisplayFormat="{0:dd.MM.yyyy}" Caption="Date Of Birth" Editable="true" />
                         <DataGridNumericColumn TItem="Employee" Field="@nameof( Employee.Childrens )" Caption="Childrens" Editable="true" Filterable="false" />
-                        <DataGridSelectColumn CustomFilter="@CustomGenderFilter" TItem="Employee" Field="@nameof( Employee.Gender )" Caption="Gender" Editable="true">
+                        <DataGridSelectColumn CustomFilter="@OnGenderCustomFilter" TItem="Employee" Field="@nameof( Employee.Gender )" Caption="Gender" Editable="true">
                             <FilterTemplate>
                                 <Select TValue="string" SelectedValue="@selectedGenderFilter" SelectedValueChanged="@(value => { selectedGenderFilter = value; context.TriggerFilterChange( selectedGenderFilter ); })">
                                     <SelectItem TValue="string" Value="@("*")">All</SelectItem>

--- a/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor.cs
+++ b/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor.cs
@@ -63,6 +63,8 @@ namespace Blazorise.Demo.Pages.Tests
         List<Employee> employeeList;
         int totalEmployees;
 
+        string selectedGenderFilter;
+
         Random random = new Random();
 
         // generated with https://mockaroo.com/
@@ -81,24 +83,24 @@ namespace Blazorise.Demo.Pages.Tests
                     new Salary { Date = new DateTime(2019,3,5), Total = 8000 }
                 }
             },
-            new Employee {Id = 4,FirstName = "Cirilo",LastName = "Douch",EMail = "cdouch3@thetimes.co.uk",City = "Wiset Chaichan",Zip = "84280",Salary = 88511.38m, IsActive = true },
-            new Employee {Id = 5,FirstName = "Bibbie",LastName = "Prahm",EMail = "bprahm4@dropbox.com",City = "Nkandla",Zip = "3859",Salary = 41665.0m },
+            new Employee {Id = 4,FirstName = "Cirilo",LastName = "Douch",EMail = "cdouch3@thetimes.co.uk",City = "Wiset Chaichan",Zip = "84280",Salary = 88511.38m, IsActive = true, Gender = "M" },
+            new Employee {Id = 5,FirstName = "Bibbie",LastName = "Prahm",EMail = "bprahm4@dropbox.com",City = "Nkandla",Zip = "3859",Salary = 41665.0m, Gender = "F" },
             new Employee {Id = 6,FirstName = "Ferd",LastName = "Bizzey",EMail = "fbizzey5@vimeo.com",City = "Arroyo Seco",Zip = "5196",Salary = 58632.74m, IsActive = true },
-            new Employee {Id = 7,FirstName = "Annalee",LastName = "Mathie",EMail = "amathie6@qq.com",City = "Qi’an",Zip = null,Salary = 38622.71m },
+            new Employee {Id = 7,FirstName = "Annalee",LastName = "Mathie",EMail = "amathie6@qq.com",City = "Qi’an",Zip = null,Salary = 38622.71m, Gender = "F" },
             new Employee {Id = 8,FirstName = "Sarajane",LastName = "Sarney",EMail = "ssarney7@phoca.cz",City = "Wagini",Zip = null,Salary = 67163.94m },
             new Employee {Id = 9,FirstName = "Lissa",LastName = "Clemenzi",EMail = "lclemenzi8@si.edu",City = "Lijiang",Zip = null,Salary = 67078.77m },
             new Employee {Id = 10,FirstName = "Taber",LastName = "Kowal",EMail = "tkowal9@ustream.tv",City = "Muhos",Zip = "91501",Salary = 70385.0m },
             new Employee {Id = 11,FirstName = "Christyna",LastName = "Blaylock",EMail = "cblaylocka@gov.uk",City = "Kruševo",Zip = "34320",Salary = 20626.15m, Childrens=4 },
             new Employee {Id = 12,FirstName = "Honoria",LastName = "Stirtle",EMail = "hstirtleb@ox.ac.uk",City = "Muang Phôn-Hông",Zip = null,Salary = 48999.42m, Childrens=1 },
-            new Employee {Id = 13,FirstName = "Gregory",LastName = "Sinden",EMail = "gsindenc@go.com",City = "Kampunglistrik",Zip = null,Salary = 38097.16m, Childrens=2 },
+            new Employee {Id = 13,FirstName = "Gregory",LastName = "Sinden",EMail = "gsindenc@go.com",City = "Kampunglistrik",Zip = null,Salary = 38097.16m, Childrens=2, Gender = "M" },
             new Employee {Id = 14,FirstName = "Obediah",LastName = "Stroban",EMail = "ostroband@nbcnews.com",City = "Almoínhas Velhas",Zip = "2755-163",Salary = 83997.47m },
             new Employee {Id = 15,FirstName = "Kellen",LastName = "Zanotti",EMail = "kzanottie@123-reg.co.uk",City = "Türkmenabat",Zip = null,Salary = 37339.0m },
             new Employee {Id = 16,FirstName = "Luelle",LastName = "Mowles",EMail = "lmowlesf@wikimedia.org",City = "Durham",Zip = "27717",Salary = 89879.64m },
             new Employee {Id = 17,FirstName = "Venita",LastName = "Petkovic",EMail = "vpetkovicg@twitpic.com",City = "Radoboj",Zip = "49232",Salary = 22979.32m },
             new Employee {Id = 18,FirstName = "Gates",LastName = "Neat",EMail = "gneath@youtu.be",City = "Solna",Zip = "170 77",Salary = 75811.63m },
-            new Employee {Id = 19,FirstName = "Roland",LastName = "Frangleton",EMail = "rfrangletoni@umich.edu",City = "Tío Pujio",Zip = "5936",Salary = 58971.76m, Childrens=3 },
+            new Employee {Id = 19,FirstName = "Roland",LastName = "Frangleton",EMail = "rfrangletoni@umich.edu",City = "Tío Pujio",Zip = "5936",Salary = 58971.76m, Childrens=3, Gender = "M" },
             new Employee {Id = 20,FirstName = "Ferdinande",LastName = "Pidcock",EMail = "fpidcockj@independent.co.uk",City = "Paris 11",Zip = "75547 CEDEX 11",Salary = 82223.65m },
-            new Employee {Id = 21,FirstName = "Clarie",LastName = "Crippin",EMail = "ccrippink@lycos.com",City = "Gostyń",Zip = "63-816",Salary = 79390.13m },
+            new Employee {Id = 21,FirstName = "Clarie",LastName = "Crippin",EMail = "ccrippink@lycos.com",City = "Gostyń",Zip = "63-816",Salary = 79390.13m, Gender = "D" },
             new Employee {Id = 22,FirstName = "Israel",LastName = "Carlin",EMail = "icarlinl@washingtonpost.com",City = "Poitiers",Zip = "86042 CEDEX 9",Salary = 36875.18m },
             new Employee {Id = 23,FirstName = "Christoper",LastName = "Moorton",EMail = "cmoortonm@gizmodo.com",City = "Jambangan",Zip = null,Salary = 76787.57m },
             new Employee {Id = 24,FirstName = "Trina",LastName = "Seamen",EMail = "tseamenn@foxnews.com",City = "Song",Zip = "54120",Salary = 43598.06m },
@@ -203,6 +205,11 @@ namespace Blazorise.Demo.Pages.Tests
         {
             currentPage = 1;
             return dataGrid.Reload();
+        }
+
+        private bool CustomGenderFilter( object searchValue )
+        {
+            return selectedGenderFilter == "*" || selectedGenderFilter == searchValue?.ToString();
         }
 
         #endregion

--- a/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor.cs
+++ b/Demos/Blazorise.Demo/Pages/Tests/DataGridPage.razor.cs
@@ -207,9 +207,14 @@ namespace Blazorise.Demo.Pages.Tests
             return dataGrid.Reload();
         }
 
-        private bool CustomGenderFilter( object searchValue )
+        private bool OnGenderCustomFilter( object itemValue, object searchValue )
         {
-            return selectedGenderFilter == "*" || selectedGenderFilter == searchValue?.ToString();
+            if ( searchValue is string genderFilter )
+            {
+                return genderFilter == "*" || genderFilter == itemValue?.ToString();
+            }
+
+            return true;
         }
 
         #endregion

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor
@@ -108,7 +108,7 @@
                                 }
                                 else
                                 {
-                                    <TextEdit Text="@column.Filter.SearchValue" TextChanged="@(async (newValue) => await OnFilterChanged(column, newValue))" />
+                                    <TextEdit Text="@column.Filter.SearchValue?.ToString()" TextChanged="@(async (newValue) => await OnFilterChanged(column, newValue))" />
                                 }
                             </TableHeaderCell>
                         }

--- a/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGrid.razor.cs
@@ -669,7 +669,7 @@ namespace Blazorise.DataGrid
                     {
                         query = from item in query
                                 let cellRealValue = column.GetValue( item )
-                                where column.CustomFilter( cellRealValue )
+                                where column.CustomFilter( cellRealValue, column.Filter.SearchValue )
                                 select item;
                     }
                     else
@@ -1353,7 +1353,7 @@ namespace Blazorise.DataGrid
         /// <summary>
         /// Handler for custom filtering on datagrid item.
         /// </summary>
-        [Parameter] public Func<TItem, bool> CustomFilter { get; set; }
+        [Parameter] public DataGridCustomFilter<TItem> CustomFilter { get; set; }
 
         /// <summary>
         /// Custom styles for header row.

--- a/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
@@ -71,7 +71,7 @@ namespace Blazorise.DataGrid
             base.Dispose( disposing );
         }
 
-        public async void OnSearchValueChanged( string filterValue )
+        public async void OnSearchValueChanged( object filterValue )
         {
             await ParentDataGrid.OnFilterChanged( this, filterValue );
         }
@@ -228,6 +228,11 @@ namespace Blazorise.DataGrid
         /// Filter value for this column.
         /// </summary>
         [Parameter] public FilterContext Filter { get; set; } = new FilterContext();
+
+        /// <summary>
+        /// Custom filter function used to override internal filtering.
+        /// </summary>
+        [Parameter] public Func<object, bool> CustomFilter { get; set; }
 
         /// <summary>
         /// Gets or sets the column initial sort direction.

--- a/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
+++ b/Source/Extensions/Blazorise.DataGrid/DataGridColumn.cs
@@ -232,7 +232,7 @@ namespace Blazorise.DataGrid
         /// <summary>
         /// Custom filter function used to override internal filtering.
         /// </summary>
-        [Parameter] public Func<object, bool> CustomFilter { get; set; }
+        [Parameter] public DataGridColumnCustomFilter CustomFilter { get; set; }
 
         /// <summary>
         /// Gets or sets the column initial sort direction.

--- a/Source/Extensions/Blazorise.DataGrid/Delegates.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Delegates.cs
@@ -1,0 +1,18 @@
+﻿namespace Blazorise.DataGrid
+{
+    /// <summary>
+    /// Represents the function for the <see cref="DataGrid{TItem}"/> custom filtering.
+    /// </summary>
+    /// <typeparam name="TItem">Type-parameter of a an object in the DataGrid.</typeparam>
+    /// <param name="item">An item in a row for which the filter is executed.</param>
+    /// <returns>True it an item has passed the filter operation.</returns>
+    public delegate bool DataGridCustomFilter<TItem>( TItem item );
+
+    /// <summary>
+    /// Represents the function for the <see cref="DataGridColumn{TItem}"/> custom filtering.
+    /// </summary>
+    /// <param name="itemValue">An item value in a column cell for which the filter is executed.</param>
+    /// <param name="searchValue">Searching value.</param>
+    /// <returns>True it the value has passed the filter operation.</returns>
+    public delegate bool DataGridColumnCustomFilter( object itemValue, object searchValue );
+}

--- a/Source/Extensions/Blazorise.DataGrid/FilterContext.cs
+++ b/Source/Extensions/Blazorise.DataGrid/FilterContext.cs
@@ -9,7 +9,7 @@
 
         private event FilterChangedEventHandler SearchValueChanged;
 
-        public delegate void FilterChangedEventHandler( string value );
+        public delegate void FilterChangedEventHandler( object value );
 
         #endregion
 
@@ -25,7 +25,7 @@
             SearchValueChanged -= listener;
         }
 
-        public void TriggerFilterChange( string value )
+        public void TriggerFilterChange( object value )
         {
             SearchValue = value;
             SearchValueChanged?.Invoke( value );
@@ -38,7 +38,7 @@
         /// <summary>
         /// Gets or sets the filter value.
         /// </summary>
-        public string SearchValue { get; set; }
+        public object SearchValue { get; set; }
 
         #endregion
     }

--- a/Source/Extensions/Blazorise.DataGrid/Models/DataGridColumnInfo.cs
+++ b/Source/Extensions/Blazorise.DataGrid/Models/DataGridColumnInfo.cs
@@ -15,7 +15,7 @@ namespace Blazorise.DataGrid
         /// <param name="searchValue">Current search value.</param>
         /// <param name="direction">Current sort direction.</param>
         /// <param name="columnType">Current column type.</param>
-        public DataGridColumnInfo( string field, string searchValue, SortDirection direction, DataGridColumnType columnType )
+        public DataGridColumnInfo( string field, object searchValue, SortDirection direction, DataGridColumnType columnType )
         {
             Field = field;
             SearchValue = searchValue;
@@ -31,7 +31,7 @@ namespace Blazorise.DataGrid
         /// <summary>
         /// Gets the column search value.
         /// </summary>
-        public string SearchValue { get; }
+        public object SearchValue { get; }
 
         /// <summary>
         /// Gets the column sort direction.

--- a/docs/_docs/extensions/datagrid.md
+++ b/docs/_docs/extensions/datagrid.md
@@ -370,6 +370,45 @@ Filter API is fairly straightforward. All you need is to attach `CustomFilter` t
 }
 ```
 
+### Custom Column Filtering
+
+Similar to the DataGrid custom filtering it is also possible to use custom filtering on per-column basis.
+
+```html
+<TextEdit @bind-Text="@customFilterValue" />
+
+<DataGrid TItem="Employee"
+        Data="@employeeList">
+    <DataGridSelectColumn CustomFilter="@OnGenderCustomFilter" TItem="Employee" Field="@nameof( Employee.Gender )" Caption="Gender" Editable="true">
+        <FilterTemplate>
+            <Select TValue="string" SelectedValue="@selectedGenderFilter" SelectedValueChanged="@(value => { selectedGenderFilter = value; context.TriggerFilterChange( selectedGenderFilter ); })">
+                <SelectItem TValue="string" Value="@("*")">All</SelectItem>
+                <SelectItem TValue="string" Value="@("M")">Male</SelectItem>
+                <SelectItem TValue="string" Value="@("F")">Female</SelectItem>
+                <SelectItem TValue="string" Value="@("D")">Diverse</SelectItem>
+            </Select>
+        </FilterTemplate>
+    </DataGridSelectColumn>
+</DataGrid>
+```
+
+```cs
+@code
+{
+    string selectedGenderFilter;
+
+    private bool OnGenderCustomFilter( object itemValue, object searchValue )
+    {
+        if ( searchValue is string genderFilter )
+        {
+            return genderFilter == "*" || genderFilter == itemValue?.ToString();
+        }
+
+        return true;
+    }
+}
+```
+
 ### Custom Row Colors
 
 You have full control over appearance of each row, including the selected rows.
@@ -720,3 +759,4 @@ Specifies the grid editing modes.
 | SortDirectionTemplate     | `RenderingFragment<SortDirection>`                                  |                     | Template for custom sort direction icon.                                                                      |
 | Validator                 | `Action<ValidatorEventArgs>`                                        |                     | Validates the input value after trying to save.                                                               |
 | ValidationPattern         | string                                                              |                     | Forces validation to use regex pattern matching instead of default validator handler.                         |
+| CustomFilter              | DataGridColumnCustomFilter                                          |                     | Custom filter function used to override internal filtering.                                                   |


### PR DESCRIPTION
resolves #1966 Multisearch in the same column
resolves #1978 Datagrid: Filter method by column // Enhancing Filter

I have added `CustomFilter` function on the DataGridColumn that can be used to override the internal filter method on per-column basis. Also, I have refactored the existing `SearchValue` from the `string` into an `object` so that it can accept any object type that later is used in the `CustomFilter` function. The downside is that it is a breaking change but I think it is not much of a problem since users only need to add `?.ToString()` to the existing SearchValue usages.

@David-Moreira What do you think? Do you have any ideas for improvements?

