### PR TITLE
Table sticky header

### DIFF
--- a/Demos/Blazorise.Demo/Pages/Tests/TablesPage.razor
+++ b/Demos/Blazorise.Demo/Pages/Tests/TablesPage.razor
@@ -1,5 +1,49 @@
 ﻿@page "/tests/tables"
 <Row>
+    <Column>
+        <Card Margin="Margin.Is4.FromBottom">
+            <CardHeader>
+                <CardTitle>Responsive</CardTitle>
+            </CardHeader>
+            <CardBody>
+                <CardText>Use <code>Responsive</code> for horizontally scrolling tables.</CardText>
+            </CardBody>
+            <CardBody>
+                <Table FixedHeader Striped FixedHeaderTableHeight="300px">
+                    <TableHeader>
+                        <TableRow>
+                            <TableHeaderCell>#</TableHeaderCell>
+                            <TableHeaderCell>Column heading</TableHeaderCell>
+                            <TableHeaderCell>Column heading</TableHeaderCell>
+                            <TableHeaderCell>Column heading</TableHeaderCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableHeaderCell>#2</TableHeaderCell>
+                            <TableHeaderCell>Column heading2</TableHeaderCell>
+                            <TableHeaderCell>Column heading2</TableHeaderCell>
+                            <TableHeaderCell>Column heading2</TableHeaderCell>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        @for ( int i = 0; i < 10; ++i )
+                        {
+                            var index = i.ToString();
+
+                            <TableRow @key="@index">
+                                <TableRowHeader>@index</TableRowHeader>
+                                <TableRowCell>Column content</TableRowCell>
+                                <TableRowCell>Column content</TableRowCell>
+                                <TableRowCell>Column content</TableRowCell>
+                            </TableRow>
+                        }
+                    </TableBody>
+                </Table>
+            </CardBody>
+        </Card>
+    </Column>
+</Row>
+
+<Row>
     <Column ColumnSize="ColumnSize.IsFull.OnDesktop.IsHalf.OnWidescreen">
         <Card Margin="Margin.Is4.OnY">
             <CardHeader>

--- a/Source/Blazorise.AntDesign/AntDesignClassProvider.cs
+++ b/Source/Blazorise.AntDesign/AntDesignClassProvider.cs
@@ -849,6 +849,8 @@ namespace Blazorise.AntDesign
 
         public override string TableResponsive() => "ant-table-responsive";
 
+        public override string TableFixedHeader() => null;
+
         #endregion
 
         #region Badge

--- a/Source/Blazorise.Bootstrap/BootstrapClassProvider.cs
+++ b/Source/Blazorise.Bootstrap/BootstrapClassProvider.cs
@@ -834,6 +834,8 @@ namespace Blazorise.Bootstrap
 
         public override string TableResponsive() => "table-responsive";
 
+        public override string TableFixedHeader() => "table-fixed-header";
+
         #endregion
 
         #region Badge

--- a/Source/Blazorise.Bootstrap/Styles/_table.scss
+++ b/Source/Blazorise.Bootstrap/Styles/_table.scss
@@ -5,3 +5,26 @@
 tr.table-row-selectable:hover {
     cursor: pointer;
 }
+
+.table-fixed-header {
+    overflow-y: auto;
+
+    .table {
+        border-collapse: separate;
+        border-spacing: 0;
+    }
+
+    thead tr th {
+        border-top: none;
+        position: sticky;
+        background: white;
+    }
+
+    thead tr:nth-child(1) th {
+        top: 0;
+    }
+
+    thead tr:nth-child(2) th {
+        top: 50px;
+    }
+}

--- a/Source/Blazorise.Bootstrap/wwwroot/blazorise.bootstrap.css
+++ b/Source/Blazorise.Bootstrap/wwwroot/blazorise.bootstrap.css
@@ -1020,3 +1020,17 @@ table.table tbody tr.selected {
 
 tr.table-row-selectable:hover {
     cursor: pointer; }
+
+.table-fixed-header {
+    overflow-y: auto; }
+    .table-fixed-header .table {
+        border-collapse: separate;
+        border-spacing: 0; }
+    .table-fixed-header thead tr th {
+        border-top: none;
+        position: sticky;
+        background: white; }
+    .table-fixed-header thead tr:nth-child(1) th {
+        top: 0; }
+    .table-fixed-header thead tr:nth-child(2) th {
+        top: 50px; }

--- a/Source/Blazorise.Bulma/BulmaClassProvider.cs
+++ b/Source/Blazorise.Bulma/BulmaClassProvider.cs
@@ -854,6 +854,8 @@ namespace Blazorise.Bulma
 
         public override string TableResponsive() => "table-container";
 
+        public override string TableFixedHeader() => "table-container-fixed-header";
+
         #endregion
 
         #region Badge

--- a/Source/Blazorise.Bulma/Styles/_table.scss
+++ b/Source/Blazorise.Bulma/Styles/_table.scss
@@ -11,3 +11,26 @@ tr.table-row-selectable {
         cursor: pointer;
     }
 }
+
+.table-container-fixed-header {
+    overflow-y: auto;
+
+    .table {
+        border-collapse: separate;
+        border-spacing: 0;
+    }
+
+    thead tr th {
+        border-top: none;
+        position: sticky;
+        background: white;
+    }
+
+    thead tr:nth-child(1) th {
+        top: 0;
+    }
+
+    thead tr:nth-child(2) th {
+        top: 42px;
+    }
+}

--- a/Source/Blazorise.Bulma/Table.razor
+++ b/Source/Blazorise.Bulma/Table.razor
@@ -1,9 +1,9 @@
 ﻿@inherits Blazorise.Table
 <CascadingValue Value="@this" IsFixed="true">
-    @if ( Responsive )
+    @if ( HasContainer )
     {
         <div style="display: grid;">
-            <div class="@ResponsiveClassNames">
+            <div class="@ContainerClassNames" style="@ContainerStyleNames">
                 <table @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames"
                        draggable="@Draggable"
                        @ondrag="@OnDragHandler"

--- a/Source/Blazorise.Bulma/wwwroot/blazorise.bulma.css
+++ b/Source/Blazorise.Bulma/wwwroot/blazorise.bulma.css
@@ -4120,6 +4120,20 @@ table.is-borderless tr {
 tr.table-row-selectable:hover, tr.table-row-selectable.is-hovered {
     cursor: pointer; }
 
+.table-container-fixed-header {
+    overflow-y: auto; }
+    .table-container-fixed-header .table {
+        border-collapse: separate;
+        border-spacing: 0; }
+    .table-container-fixed-header thead tr th {
+        border-top: none;
+        position: sticky;
+        background: white; }
+    .table-container-fixed-header thead tr:nth-child(1) th {
+        top: 0; }
+    .table-container-fixed-header thead tr:nth-child(2) th {
+        top: 42px; }
+
 .tab-pane {
     display: none; }
     .tab-pane.is-active {

--- a/Source/Blazorise.Frolic/FrolicClassProvider.cs
+++ b/Source/Blazorise.Frolic/FrolicClassProvider.cs
@@ -875,6 +875,8 @@ namespace Blazorise.Frolic
 
         public override string TableResponsive() => "e-table-responsive";
 
+        public override string TableFixedHeader() => null;
+
         #endregion
 
         #region Badge

--- a/Source/Blazorise/Components/Table/Table.razor
+++ b/Source/Blazorise/Components/Table/Table.razor
@@ -1,9 +1,9 @@
 ﻿@namespace Blazorise
 @inherits BaseDraggableComponent
 <CascadingValue Value="@this" IsFixed="true">
-    @if ( Responsive )
+    @if ( HasContainer )
     {
-        <div class="@ResponsiveClassNames">
+        <div class="@ContainerClassNames" style="@ContainerStyleNames">
             <table @ref="@ElementRef" id="@ElementId" class="@ClassNames" style="@StyleNames"
                    draggable="@Draggable"
                    @ondrag="@OnDragHandler"

--- a/Source/Blazorise/Components/Table/Table.razor.cs
+++ b/Source/Blazorise/Components/Table/Table.razor.cs
@@ -26,6 +26,10 @@ namespace Blazorise
 
         private bool responsive;
 
+        private bool fixedHeader;
+
+        private string fixedHeaderTableHeight = "300px";
+
         #endregion
 
         #region Constructors
@@ -35,7 +39,8 @@ namespace Blazorise
         /// </summary>
         public Table()
         {
-            ResponsiveClassBuilder = new ClassBuilder( BuildResponsiveClasses );
+            ContainerClassBuilder = new ClassBuilder( BuildContainerClasses );
+            ContainerStyleBuilder = new StyleBuilder( BuildContainerStyles );
         }
 
         #endregion
@@ -60,9 +65,30 @@ namespace Blazorise
         /// Builds a list of classnames for the responsive container element.
         /// </summary>
         /// <param name="builder">Class builder used to append the classnames.</param>
-        private void BuildResponsiveClasses( ClassBuilder builder )
+        protected virtual void BuildContainerClasses( ClassBuilder builder )
         {
-            builder.Append( ClassProvider.TableResponsive() );
+            builder.Append( ClassProvider.TableResponsive(), Responsive );
+            builder.Append( ClassProvider.TableFixedHeader(), FixedHeader );
+        }
+
+        /// <summary>
+        /// Builds a list of styles for the responsive container element.
+        /// </summary>
+        /// <param name="builder">Style builder used to append the classnames.</param>
+        protected virtual void BuildContainerStyles( StyleBuilder builder )
+        {
+            if ( !string.IsNullOrEmpty( FixedHeaderTableHeight ) )
+            {
+                builder.Append( $"height: {FixedHeaderTableHeight};" );
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void DirtyStyles()
+        {
+            ContainerStyleBuilder.Dirty();
+
+            base.DirtyStyles();
         }
 
         #endregion
@@ -72,12 +98,27 @@ namespace Blazorise
         /// <summary>
         /// Class builder used to build the classnames for responsive element.
         /// </summary>
-        protected ClassBuilder ResponsiveClassBuilder { get; private set; }
+        protected ClassBuilder ContainerClassBuilder { get; private set; }
 
         /// <summary>
         /// Gets the classname for a responsive element.
         /// </summary>
-        protected string ResponsiveClassNames => ResponsiveClassBuilder.Class;
+        protected string ContainerClassNames => ContainerClassBuilder.Class;
+
+        /// <summary>
+        /// Style builder used to build the stylenames for responsive or fixed element.
+        /// </summary>
+        protected StyleBuilder ContainerStyleBuilder { get; private set; }
+
+        /// <summary>
+        /// Gets the styles for a responsive element.
+        /// </summary>
+        protected string ContainerStyleNames => ContainerStyleBuilder.Styles;
+
+        /// <summary>
+        /// True if table needs to be placed inside of container element.
+        /// </summary>
+        protected bool HasContainer => Responsive || FixedHeader;
 
         /// <summary>
         /// Makes the table to fill entire horizontal space.
@@ -181,6 +222,37 @@ namespace Blazorise
                 responsive = value;
 
                 DirtyClasses();
+            }
+        }
+
+        /// <summary>
+        ///  Makes table have a fixed header and enabling a scrollbar in the table body.
+        /// </summary>
+        [Parameter]
+        public bool FixedHeader
+        {
+            get => fixedHeader;
+            set
+            {
+                fixedHeader = value;
+
+                DirtyClasses();
+            }
+        }
+
+        /// <summary>
+        /// Sets table fixed header feature table max height (defaults to 300px).
+        /// </summary>
+        [Parameter]
+        public string FixedHeaderTableHeight
+        {
+            get => fixedHeaderTableHeight;
+            set
+            {
+                fixedHeaderTableHeight = value;
+
+                DirtyClasses();
+                DirtyStyles();
             }
         }
 

--- a/Source/Blazorise/Interfaces/IClassProvider.cs
+++ b/Source/Blazorise/Interfaces/IClassProvider.cs
@@ -799,6 +799,8 @@ namespace Blazorise
 
         string TableResponsive();
 
+        string TableFixedHeader();
+
         #endregion
 
         #region Badge

--- a/Source/Blazorise/Providers/ClassProvider.cs
+++ b/Source/Blazorise/Providers/ClassProvider.cs
@@ -807,6 +807,8 @@ namespace Blazorise
 
         public abstract string TableResponsive();
 
+        public abstract string TableFixedHeader();
+
         #endregion
 
         #region Badge

--- a/Source/Blazorise/Providers/EmptyClassProvider.cs
+++ b/Source/Blazorise/Providers/EmptyClassProvider.cs
@@ -807,6 +807,8 @@ namespace Blazorise.Providers
 
         public string TableResponsive() => null;
 
+        public string TableFixedHeader() => null;
+
         #endregion
 
         #region Badge


### PR DESCRIPTION
Based on work from #2214 because it was easier for me to create a separate PR than to refactor the existing. The problem with 2214 PR is that it was changing a lot of table styles and so borderless, stripped, etc would not work.

In this PR I have implemented a working example for Boostrap and Bulma. Other providers will be done soon. Styles changing is kept to a minimum.

@David-Moreira I must admit doing this is a lot harder than anticipated. So far this is the only example with CSS that was working for me. I even considered JavaScript but we'll see, maybe it is not needed. When you have some time please test it. I will continue with work in the meantime. Thanks!