### PR TITLE
set dotNetObjectRef to null on dispose

### DIFF
--- a/Source/Blazorise/Components/Modal/Modal.razor.cs
+++ b/Source/Blazorise/Components/Modal/Modal.razor.cs
@@ -101,6 +101,7 @@ namespace Blazorise
                 }
 
                 DisposeDotNetObjectRef( dotNetObjectRef );
+                dotNetObjectRef = null;
 
                 // TODO: implement IAsyncDisposable once it is supported by Blazor!
                 //


### PR DESCRIPTION
I'm getting an error when using GridBlazor with a custom filter Modal component.
This was something introduced in 0.9.0.0, but I haven't been able to narrow down exactly what is causing the modal to get disposed multiple times... 

Using a modal outside of the GridBlazor custom filter works exactly as advertised.

Setting the dotNetObjectRef to null when the object is disposed, appears to have resolved the problem.

```
blazor.webassembly.js:1 crit: Microsoft.AspNetCore.Components.WebAssembly.Rendering.WebAssemblyRenderer[100]
      Unhandled exception rendering component: Cannot access a disposed object.
      Object name: 'DotNetObjectReference`1'.
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'DotNetObjectReference`1'.
   at Microsoft.JSInterop.DotNetObjectReference`1[[Blazorise.CloseActivatorAdapter, Blazorise, Version=0.9.3.6, Culture=neutral, PublicKeyToken=null]].ThrowIfDisposed()
...
 at Blazorise.Modal.<HandleVisibilityStyles>b__14_0()
   at Blazorise.Base.BaseAfterRenderComponent.OnAfterRenderAsync(Boolean firstRender)
```