### PR TITLE
Bulma GenerateAlertVariantStyles fix

### DIFF
--- a/Source/Blazorise.Bulma/BulmaThemeGenerator.cs
+++ b/Source/Blazorise.Bulma/BulmaThemeGenerator.cs
@@ -352,7 +352,7 @@ namespace Blazorise.Bulma
             var text = ToHex( textColor );
             var alertLink = ToHex( alertLinkColor );
 
-            sb.Append( $".notification-{variant}" ).Append( "{" )
+            sb.Append( $".notification.is-{variant}" ).Append( "{" )
                 .Append( $"color: {text};" )
                 .Append( GetGradientBg( theme, background, options?.GradientBlendPercentage ) )
                 .Append( $"border-color: {border};" )


### PR DESCRIPTION
Hello, I think I found a small bug in Bulma theme generator. Bulma alerts are styled like this `.notification.is-primary` and not like this `.notification-primary`. So the styles inside ThemeAlertOptions where not applied to the Alert component. Now it works.